### PR TITLE
remove to ELB host name in health routing

### DIFF
--- a/service-files/annotations-api-sidekick@.service
+++ b/service-files/annotations-api-sidekick@.service
@@ -4,14 +4,14 @@ PartOf=annotations-api@%i.service
 After=annotations-api@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/backends/annotations-api/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/annotations-api/frontend '{\"Type\": \"http\", \"BackendId\": \"annotations-api\", \"Route\": \"PathRegexp(`/content/.*/annotations.*`) && Host(`annotations-api`)\"}'; \
   etcdctl setdir /services/annotations-api --ttl 60; \
   etcdctl setdir /vulcand/backends/annotations-api/servers --ttl 60; \
   \
-  etcdctl set /vulcand/frontends/annotations-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"annotations-api\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/annotations-api/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/annotations-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"annotations-api\\\", \\\"Route\\\":\\\"Path(\`/health/annotations-api/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/annotations-api-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/annotations-api(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/api-policy-component-sidekick@.service
+++ b/service-files/api-policy-component-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=api-policy-component@%i.service
 After=api-policy-component@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$HOSTNAME; \
   etcdctl set /vulcand/backends/api-policy-component/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/api-policy-component/frontend '{\"Type\": \"http\", \"BackendId\": \"api-policy-component\", \"Route\": \"PathRegexp(`/.*`) && Host(`api-policy-component`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/api-policy-component-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"api-policy-component\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/api-policy-component/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/api-policy-component-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"api-policy-component\\\", \\\"Route\\\":\\\"Path(\`/health/api-policy-component/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/api-policy-component-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/api-policy-component(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/binary-ingester-sidekick@.service
+++ b/service-files/binary-ingester-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=binary-ingester@%i.service
 After=binary-ingester@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$HOSTNAME; \
   etcdctl set /vulcand/backends/binary-ingester/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/binary-ingester/frontend '{\"Type\": \"http\", \"BackendId\": \"binary-ingester\", \"Route\": \"Host(`binary-ingester`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/binary-ingester-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"binary-ingester\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/binary-ingester/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/binary-ingester-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"binary-ingester\\\", \\\"Route\\\":\\\"Path(\`/health/binary-ingester/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/binary-ingester-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/binary-ingester(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/binary-writer-sidekick@.service
+++ b/service-files/binary-writer-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=binary-writer@%i.service
 After=binary-writer@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$HOSTNAME; \
   etcdctl set /vulcand/backends/binary-writer/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/binary-writer/frontend '{\"Type\": \"http\", \"BackendId\": \"binary-writer\", \"Route\": \"Host(`binary-writer`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/binary-writer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"binary-writer\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/binary-writer/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/binary-writer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"binary-writer\\\", \\\"Route\\\":\\\"Path(\`/health/binary-writer/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/binary-writer-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/binary-writer(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/cms-notifier-sidekick@.service
+++ b/service-files/cms-notifier-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=cms-notifier@%i.service
 After=cms-notifier@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$(/usr/bin/ifconfig eth0 | sed -n '2 p' | awk '{print $2}' | cut -d':' -f2); \
   etcdctl set /vulcand/backends/cms-notifier/backend '{\"Type\": \"http\"}' ; \
   etcdctl set /vulcand/frontends/cms-notifier/frontend \"{\\\"Type\\\": \\\"http\\\", \\\"BackendId\\\": \\\"cms-notifier\\\", \\\"Route\\\": \\\"PathRegexp(\`/.*\`) && Host(\`cms-notifier\`)\\\"}\" ; \
   \
-  etcdctl set /vulcand/frontends/cms-notifier-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"cms-notifier\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/cms-notifier/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/cms-notifier-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"cms-notifier\\\", \\\"Route\\\":\\\"Path(\`/health/cms-notifier/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/cms-notifier-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/cms-notifier(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/content-by-concept-api-sidekick@.service
+++ b/service-files/content-by-concept-api-sidekick@.service
@@ -4,14 +4,14 @@ PartOf=content-by-concept-api@%i.service
 After=content-by-concept-api@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/backends/content-by-concept-api/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/content-by-concept-api/frontend '{\"Type\": \"http\", \"BackendId\": \"content-by-concept-api\", \"Route\": \"PathRegexp(`/content?isAnnotatedBy=.*`) && Host(`content-by-concept-api`)\"}'; \
   etcdctl setdir /services/content-by-concept-api --ttl 60; \
   etcdctl setdir /vulcand/backends/content-by-concept-api/servers --ttl 60; \
   \
-  etcdctl set /vulcand/frontends/content-by-concept-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"content-by-concept-api\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/content-by-concept-api/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/content-by-concept-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"content-by-concept-api\\\", \\\"Route\\\":\\\"Path(\`/health/content-by-concept-api/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/content-by-concept-api-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/content-by-concept-api(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/content-writer-sesame-sidekick@.service
+++ b/service-files/content-writer-sesame-sidekick@.service
@@ -4,7 +4,7 @@ PartOf=content-writer-sesame@%i.service
 After=content-writer-sesame@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$(/usr/bin/ifconfig eth0 | sed -n '2 p' | awk '{print $2}' | cut -d':' -f2); \
   etcdctl set /vulcand/backends/content-writer-sesame/backend '{\"Type\": \"http\"}'; \
@@ -12,7 +12,7 @@ ExecStart=/bin/sh -c "\
   etcdctl setdir /services/content-writer-sesame --ttl 60; \
   etcdctl setdir /vulcand/backends/content-writer-sesame/servers --ttl 60; \
   \
-  etcdctl set /vulcand/frontends/content-writer-sesame-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"content-writer-sesame\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/content-writer-sesame/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/content-writer-sesame-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"content-writer-sesame\\\", \\\"Route\\\":\\\"Path(\`/health/content-writer-sesame/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/content-writer-sesame-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/content-writer-sesame(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/document-store-api-sidekick@.service
+++ b/service-files/document-store-api-sidekick@.service
@@ -4,14 +4,14 @@ PartOf=document-store-api@%i.service
 After=document-store-api@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$HOSTNAME; \
   etcdctl set /vulcand/backends/document-store-api/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/document-store-api/frontend '{\"Type\": \"http\", \"BackendId\": \"document-store-api\", \"Route\": \"PathRegexp(`/.*`) && Host(`document-store-api`)\"}'; \
   etcdctl set /vulcand/frontends/document-store-api2/frontend '{\"Type\": \"http\", \"BackendId\": \"document-store-api\", \"Route\": \"PathRegexp(`/lists/.*`) && Host(`public-services`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/document-store-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"document-store-api\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/document-store-api/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/document-store-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"document-store-api\\\", \\\"Route\\\":\\\"Path(\`/health/document-store-api/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/document-store-api-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/document-store-api(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/enriched-content-read-api-sidekick@.service
+++ b/service-files/enriched-content-read-api-sidekick@.service
@@ -4,14 +4,14 @@ PartOf=enriched-content-read-api@%i.service
 After=enriched-content-read-api@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/backends/enriched-content-read-api/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/enriched-content-read-api/frontend '{\"Type\": \"http\", \"BackendId\": \"enriched-content-read-api\", \"Route\": \"PathRegexp(`/enrichedcontent/.*`) && Host(`enriched-content-read-api`)\"}'; \
   etcdctl setdir /services/enriched-content-read-api --ttl 60; \
   etcdctl setdir /vulcand/backends/enriched-content-read-api/servers --ttl 60; \
   \
-  etcdctl set /vulcand/frontends/enriched-content-read-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"enriched-content-read-api\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/enriched-content-read-api/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/enriched-content-read-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"enriched-content-read-api\\\", \\\"Route\\\":\\\"Path(\`/health/enriched-content-read-api/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/enriched-content-read-api-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/enriched-content-read-api(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/fastftxf-sidekick@.service
+++ b/service-files/fastftxf-sidekick@.service
@@ -4,7 +4,7 @@ PartOf=fastftxf@%i.service
 After=fastftxf@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c " \
   export HOST_IP=$(/usr/bin/ifconfig docker0 | sed -n '2 p' | awk '{print $2}' | cut -d':' -f2); \
   while true; do \
@@ -15,7 +15,7 @@ ExecStart=/bin/sh -c " \
     etcdctl set /vulcand/backends/fastft-transformer/backend '{\"Type\": \"http\"}' --ttl 60; \
     etcdctl set /vulcand/backends/fastft-transformer/servers/srv%i \"{\\\"url\\\": \\\"http://$HOST_IP:$FASTFT_TRANSFORMER_PORT\\\"}\" --ttl 60; \
     etcdctl set /vulcand/frontends/fastft-transformer/frontend '{\"Type\": \"http\", \"BackendId\": \"fastft-transformer\", \"Route\": \"PathRegexp(`/.*`) && Host(`fastft-transformer`)\"}' --ttl 60; \
-    etcdctl set /vulcand/frontends/fastft-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"nativerw\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/fastft-transformer/__health\`)\\\"}\"; \
+    etcdctl set /vulcand/frontends/fastft-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"nativerw\\\", \\\"Route\\\":\\\"Path(\`/health/fastft-transformer/__health\`)\\\"}\"; \
     etcdctl set /vulcand/frontends/fastft-transformer-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/fastft-transformer(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
     sleep 45; \
   done"

--- a/service-files/ingester-content-sidekick@.service
+++ b/service-files/ingester-content-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=ingester-content@%i.service
 After=ingester-content@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$HOSTNAME; \
   etcdctl set /vulcand/backends/ingester-content/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/ingester-content/frontend '{\"Type\": \"http\", \"BackendId\": \"ingester-content\", \"Route\": \"Host(`ingester-content`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/ingester-content-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"ingester-content\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/ingester-content/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/ingester-content-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"ingester-content\\\", \\\"Route\\\":\\\"Path(\`/health/ingester-content/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/ingester-content-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/ingester-content(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/ingester-semantic-sidekick@.service
+++ b/service-files/ingester-semantic-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=ingester-semantic@%i.service
 After=ingester-semantic@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$HOSTNAME; \
   etcdctl set /vulcand/backends/ingester-semantic/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/ingester-semantic/frontend '{\"Type\": \"http\", \"BackendId\": \"ingester-semantic\", \"Route\": \"Host(`ingester-semantic`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/ingester-semantic-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"ingester-semantic\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/ingester-semantic/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/ingester-semantic-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"ingester-semantic\\\", \\\"Route\\\":\\\"Path(\`/health/ingester-semantic/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/ingester-semantic-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/ingester-semantic(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/methode-article-transformer-sidekick@.service
+++ b/service-files/methode-article-transformer-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=methode-article-transformer@%i.service
 After=methode-article-transformer@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export MAT_IP=$(/usr/bin/ifconfig eth0 | sed -n '2 p' | awk '{print $2}' | cut -d':' -f2); \
   etcdctl set /vulcand/backends/methode-article-transformer/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/methode-article-transformer/frontend '{\"Type\": \"http\", \"BackendId\": \"methode-article-transformer\", \"Route\": \"PathRegexp(`/.*`) && Host(`methode-article-transformer`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/methode-article-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"methode-article-transformer\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/methode-article-transformer/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/methode-article-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"methode-article-transformer\\\", \\\"Route\\\":\\\"Path(\`/health/methode-article-transformer/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/methode-article-transformer-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/methode-article-transformer(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/methode-content-importer-sidekick@.service
+++ b/service-files/methode-content-importer-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=methode-content-importer@%i.service
 After=methode-content-importer@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export METHODE_CONTENT_IMPORTER_IP=$(/usr/bin/ifconfig eth0 | sed -n '2 p' | awk '{print $2}' | cut -d':' -f2); \
   etcdctl set /vulcand/backends/methode-content-importer/backend '{\"Type\": \"http\"}' ; \
   etcdctl set /vulcand/frontends/methode-content-importer/frontend '{\"Type\": \"http\", \"BackendId\": \"methode-content-importer\", \"Route\": \"PathRegexp(`/.*`) && Host(`methode-content-importer`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/methode-content-importer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"methode-content-importer\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/methode-content-importer/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/methode-content-importer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"methode-content-importer\\\", \\\"Route\\\":\\\"Path(\`/health/methode-content-importer/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/methode-content-importer-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/methode-content-importer(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/methode-image-binary-transformer-sidekick@.service
+++ b/service-files/methode-image-binary-transformer-sidekick@.service
@@ -4,14 +4,14 @@ PartOf=methode-image-binary-transformer@%i.service
 After=methode-image-binary-transformer@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export METHODE_IMAGE_BINARY_TRANSFORMER_IP=$(/usr/bin/ifconfig eth0 | sed -n '2 p' | awk '{print $2}' | cut -d':' -f2); \
   export _IP=$(/usr/bin/ifconfig eth0 | sed -n '2 p' | awk '{print $2}' | cut -d':' -f2); \
   etcdctl set /vulcand/backends/methode-image-binary-transformer/backend '{\"Type\": \"http\"}' ; \
   etcdctl set /vulcand/frontends/methode-image-binary-transformer/frontend '{\"Type\": \"http\", \"BackendId\": \"methode-image-binary-transformer\", \"Route\": \"PathRegexp(`/.*`) && Host(`methode-image-binary-transformer`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/methode-image-binary-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"methode-image-binary-transformer\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/methode-image-binary-transformer/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/methode-image-binary-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"methode-image-binary-transformer\\\", \\\"Route\\\":\\\"Path(\`/health/methode-image-binary-transformer/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/methode-image-binary-transformer-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/methode-image-binary-transformer(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/methode-image-model-transformer-sidekick@.service
+++ b/service-files/methode-image-model-transformer-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=methode-image-model-transformer-sidekick@%i.service
 After=methode-image-model-transformer-sidekick@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$HOSTNAME; \
   etcdctl set /vulcand/backends/methode-image-model-transformer/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/methode-image-model-transformer/frontend '{\"Type\": \"http\", \"BackendId\": \"methode-image-model-transformer\", \"Route\": \"PathRegexp(`/.*`) && Host(`methode-image-model-transformer`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/methode-image-model-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"methode-image-model-transformer\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/methode-image-model-transformer/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/methode-image-model-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"methode-image-model-transformer\\\", \\\"Route\\\":\\\"Path(\`/health/methode-image-model-transformer/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/methode-image-model-transformer-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/methode-image-model-transformer(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/nativerw-sidekick@.service
+++ b/service-files/nativerw-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=nativerw@%i.service
 After=nativerw@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$HOSTNAME; \
   etcdctl set /vulcand/backends/nativerw/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/nativerw/frontend '{\"Type\": \"http\", \"BackendId\": \"nativerw\", \"Route\": \"PathRegexp(`/.*`) && Host(`nativerw`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/nativerw-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"nativerw\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/nativerw/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/nativerw-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"nativerw\\\", \\\"Route\\\":\\\"Path(\`/health/nativerw/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/nativerw-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/nativerw(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/organisation-read-api-sidekick@.service
+++ b/service-files/organisation-read-api-sidekick@.service
@@ -4,14 +4,14 @@ PartOf=organisation-read-api@%i.service
 After=organisation-read-api@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/backends/organisation-read-api/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/organisation-read-api/frontend '{\"Type\": \"http\", \"BackendId\": \"organisation-read-api\", \"Route\": \"PathRegexp(`/organisations/.*`) && Host(`organisation-read-api`)\"}'; \
   etcdctl setdir /services/organisation-read-api --ttl 60; \
   etcdctl setdir /vulcand/backends/organisation-read-api/servers --ttl 60; \
   \
-  etcdctl set /vulcand/frontends/organisation-read-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"organisation-read-api\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/organisation-read-api/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/organisation-read-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"organisation-read-api\\\", \\\"Route\\\":\\\"Path(\`/health/organisation-read-api/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/organisation-read-api-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/organisation-read-api(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/people-read-api-sidekick@.service
+++ b/service-files/people-read-api-sidekick@.service
@@ -4,14 +4,14 @@ PartOf=people-read-api@%i.service
 After=people-read-api@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/backends/people-read-api/backend '{\"Type\": \"http\"}'; \
   etcdctl set /vulcand/frontends/people-read-api/frontend '{\"Type\": \"http\", \"BackendId\": \"people-read-api\", \"Route\": \"PathRegexp(`/people/.*`) && Host(`people-read-api`)\"}'; \
   etcdctl setdir /services/people-read-api --ttl 60; \
   etcdctl setdir /vulcand/backends/people-read-api/servers --ttl 60; \
   \
-  etcdctl set /vulcand/frontends/people-read-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"people-read-api\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/people-read-api/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/people-read-api-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"people-read-api\\\", \\\"Route\\\":\\\"Path(\`/health/people-read-api/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/people-read-api-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/people-read-api(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/semantic-reader-sidekick@.service
+++ b/service-files/semantic-reader-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=semantic-reader@%i.service
 After=semantic-reader@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$HOSTNAME; \
   etcdctl set /vulcand/frontends/semantic-reader/frontend '{\"Type\": \"http\", \"BackendId\": \"semantic-reader\", \"Route\": \"PathRegexp(`/content/.*`) && Host(`public-services`)\"}'; \
   etcdctl set /vulcand/backends/semantic-reader/backend '{\"Type\": \"http\"}'; \
   \
-  etcdctl set /vulcand/frontends/semantic-reader-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"semantic-reader\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/semantic-reader/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/semantic-reader-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"semantic-reader\\\", \\\"Route\\\":\\\"Path(\`/health/semantic-reader/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/semantic-reader-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/semantic-reader(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/wp-notifier-sidekick@.service
+++ b/service-files/wp-notifier-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=wp-notifier@%i.service
 After=wp-notifier@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export WP_NOTIFIER_IP=$(/usr/bin/ifconfig eth0 | sed -n '2 p' | awk '{print $2}' | cut -d':' -f2); \
   etcdctl set /vulcand/backends/wp-notifier/backend '{\"Type\": \"http\"}' ; \
   etcdctl set /vulcand/frontends/wp-notifier/frontend '{\"Type\": \"http\", \"BackendId\": \"wp-notifier\", \"Route\": \"PathRegexp(`/.*`) && Host(`wp-notifier`)\"}'; \
   \
-  etcdctl set /vulcand/frontends/wp-notifier-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"wp-notifier\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/wp-notifier/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/wp-notifier-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"wp-notifier\\\", \\\"Route\\\":\\\"Path(\`/health/wp-notifier/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/wp-notifier-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/wp-notifier(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \

--- a/service-files/wp-transformer-sidekick@.service
+++ b/service-files/wp-transformer-sidekick@.service
@@ -4,13 +4,13 @@ PartOf=wp-transformer@%i.service
 After=wp-transformer@%i.service
 
 [Service]
-Environment="ELB_HOSTNAME=cluster-elb-1694467668.eu-west-1.elb.amazonaws.com"
+
 ExecStart=/bin/sh -c "\
   export HOST_IP=$(/usr/bin/ifconfig eth0 | sed -n '2 p' | awk '{print $2}' | cut -d':' -f2); \
   etcdctl set /vulcand/backends/wp-transformer/backend '{\"Type\": \"http\"}' ; \
   etcdctl set /vulcand/frontends/wp-transformer/frontend \"{\\\"Type\\\": \\\"http\\\", \\\"BackendId\\\": \\\"wp-transformer\\\", \\\"Route\\\": \\\"PathRegexp(\`/.*\`) && Host(\`wp-transformer\`)\\\"}\" ; \
   \
-  etcdctl set /vulcand/frontends/wp-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"wp-transformer\\\", \\\"Route\\\":\\\"Host(\`$ELB_HOSTNAME\`) && Path(\`/health/wp-transformer/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/wp-transformer-health/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"wp-transformer\\\", \\\"Route\\\":\\\"Path(\`/health/wp-transformer/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/wp-transformer-health/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/wp-transformer(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   \
   while true; do \


### PR DESCRIPTION
remove reference to elb host almost everywhere. (all services except aggregating health check, which may or may not need more thought)