### PR TITLE
Sidekicks to ReloadPropagatedFrom main services

### DIFF
--- a/service-files/aggregate-healthcheck-sidekick@.service
+++ b/service-files/aggregate-healthcheck-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Aggregate Healthcheck Sidekick
 PartOf=aggregate-healthcheck@%i.service
+ReloadPropagatedFrom=aggregate-healthcheck@%i.service
 After=aggregate-healthcheck@%i.service
 
 [Service]

--- a/service-files/annotations-api-sidekick@.service
+++ b/service-files/annotations-api-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Annotations API Sidekick
 PartOf=annotations-api@%i.service
+ReloadPropagatedFrom=annotations-api@%i.service
 After=annotations-api@%i.service
 
 [Service]

--- a/service-files/api-policy-component-sidekick@.service
+++ b/service-files/api-policy-component-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=api policy component
 PartOf=api-policy-component@%i.service
+ReloadPropagatedFrom=api-policy-component@%i.service
 After=api-policy-component@%i.service
 
 [Service]

--- a/service-files/binary-ingester-sidekick@.service
+++ b/service-files/binary-ingester-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Binary Ingester Sidekick
 PartOf=binary-ingester@%i.service
+ReloadPropagatedFrom=binary-ingester@%i.service
 After=binary-ingester@%i.service
 
 [Service]

--- a/service-files/binary-writer-sidekick@.service
+++ b/service-files/binary-writer-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Binary Writer Sidekick
 PartOf=binary-writer@%i.service
+ReloadPropagatedFrom=binary-writer@%i.service
 After=binary-writer@%i.service
 
 [Service]

--- a/service-files/content-by-concept-api-sidekick@.service
+++ b/service-files/content-by-concept-api-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Content-By-Concept API Sidekick
 PartOf=content-by-concept-api@%i.service
+ReloadPropagatedFrom=content-by-concept-api@%i.service
 After=content-by-concept-api@%i.service
 
 [Service]

--- a/service-files/content-writer-sesame-sidekick@.service
+++ b/service-files/content-writer-sesame-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Content writer sesame
 PartOf=content-writer-sesame@%i.service
+ReloadPropagatedFrom=content-writer-sesame@%i.service
 After=content-writer-sesame@%i.service
 
 [Service]

--- a/service-files/document-store-api-sidekick@.service
+++ b/service-files/document-store-api-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Document store api sidekick
 PartOf=document-store-api@%i.service
+ReloadPropagatedFrom=document-store-api@%i.service
 After=document-store-api@%i.service
 
 [Service]

--- a/service-files/enriched-content-read-api-sidekick@.service
+++ b/service-files/enriched-content-read-api-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Enriched Content Read API Sidekick
 PartOf=enriched-content-read-api@%i.service
+ReloadPropagatedFrom=enriched-content-read-api@%i.service
 After=enriched-content-read-api@%i.service
 
 [Service]

--- a/service-files/fastftxf-sidekick@.service
+++ b/service-files/fastftxf-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=FastFTXF Sidekick
 PartOf=fastftxf@%i.service
+ReloadPropagatedFrom=fastftxf@%i.service
 After=fastftxf@%i.service
 
 [Service]

--- a/service-files/graphdb-master-sidekick@.service
+++ b/service-files/graphdb-master-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=GraphDB Master Sidekick
 PartOf=graphdb-master@%i.service
+ReloadPropagatedFrom=graphdb-master@%i.service
 After=graphdb-master@%i.service
 
 [Service]

--- a/service-files/graphdb-worker-sidekick@.service
+++ b/service-files/graphdb-worker-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=GraphDB Worker Sidekick
 PartOf=graphdb-worker@%i.service
+ReloadPropagatedFrom=graphdb-worker@%i.service
 After=graphdb-worker@%i.service
 
 [Service]

--- a/service-files/ingester-content-sidekick@.service
+++ b/service-files/ingester-content-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Ingester content store sidekick
 PartOf=ingester-content@%i.service
+ReloadPropagatedFrom=ingester-content@%i.service
 After=ingester-content@%i.service
 
 [Service]

--- a/service-files/ingester-semantic-sidekick@.service
+++ b/service-files/ingester-semantic-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Ingester semantic store sidekick
 PartOf=ingester-semantic@%i.service
+ReloadPropagatedFrom=ingester-semantic@%i.service
 After=ingester-semantic@%i.service
 
 [Service]

--- a/service-files/kafka-sidekick.service
+++ b/service-files/kafka-sidekick.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Kafka Sidekick
 PartOf=kafka.service
+ReloadPropagatedFrom=kafka.service
 After=kafka.service
 
 [Service]

--- a/service-files/methode-article-transformer-sidekick@.service
+++ b/service-files/methode-article-transformer-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=method article transformer sidekick
 PartOf=methode-article-transformer@%i.service
+ReloadPropagatedFrom=methode-article-transformer@%i.service
 After=methode-article-transformer@%i.service
 
 [Service]

--- a/service-files/methode-content-importer-sidekick@.service
+++ b/service-files/methode-content-importer-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Methode Content Importer Sidekick
 PartOf=methode-content-importer@%i.service
+ReloadPropagatedFrom=methode-content-importer@%i.service
 After=methode-content-importer@%i.service
 
 [Service]

--- a/service-files/methode-image-binary-transformer-sidekick@.service
+++ b/service-files/methode-image-binary-transformer-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Methode Image Binary Transformer
 PartOf=methode-image-binary-transformer@%i.service
+ReloadPropagatedFrom=methode-image-binary-transformer@%i.service
 After=methode-image-binary-transformer@%i.service
 
 [Service]

--- a/service-files/methode-image-model-transformer-sidekick@.service
+++ b/service-files/methode-image-model-transformer-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Document store api sidekick
 PartOf=methode-image-model-transformer-sidekick@%i.service
+ReloadPropagatedFrom=methode-image-model-transformer-sidekick@%i.service
 After=methode-image-model-transformer-sidekick@%i.service
 
 [Service]

--- a/service-files/mongodb-sidekick@.service
+++ b/service-files/mongodb-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=MongoDB Sidekick
 PartOf=mongodb@%i.service
+ReloadPropagatedFrom=mongodb@%i.service
 After=mongodb@%i.service
 
 [Service]

--- a/service-files/nativerw-sidekick@.service
+++ b/service-files/nativerw-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Nativerw sidekick
 PartOf=nativerw@%i.service
+ReloadPropagatedFrom=nativerw@%i.service
 After=nativerw@%i.service
 
 [Service]

--- a/service-files/organisation-read-api-sidekick@.service
+++ b/service-files/organisation-read-api-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Organisation Read API Sidekick
 PartOf=organisation-read-api@%i.service
+ReloadPropagatedFrom=organisation-read-api@%i.service
 After=organisation-read-api@%i.service
 
 [Service]

--- a/service-files/people-read-api-sidekick@.service
+++ b/service-files/people-read-api-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=People Read API Sidekick
 PartOf=people-read-api@%i.service
+ReloadPropagatedFrom=people-read-api@%i.service
 After=people-read-api@%i.service
 
 [Service]

--- a/service-files/semantic-reader-sidekick@.service
+++ b/service-files/semantic-reader-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Semantic reader api sidekick
 PartOf=semantic-reader@%i.service
+ReloadPropagatedFrom=semantic-reader@%i.service
 After=semantic-reader@%i.service
 
 [Service]

--- a/service-files/splunk-sidekick.service
+++ b/service-files/splunk-sidekick.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Splunk Sidekick
 PartOf=splunk.service
+ReloadPropagatedFrom=splunk.service
 After=splunk.service
 
 [Service]

--- a/service-files/synthetic-image-publication-monitor-sidekick@.service
+++ b/service-files/synthetic-image-publication-monitor-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Synthetic Image Publication Monitor Sidekick
 PartOf=synthetic-image-publication-monitor@%i.service
+ReloadPropagatedFrom=synthetic-image-publication-monitor@%i.service
 After=synthetic-image-publication-monitor@%i.service
 
 [Service]

--- a/service-files/varnish-sidekick@.service
+++ b/service-files/varnish-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Varnish Sidekick
 PartOf=varnish@%i.service
+ReloadPropagatedFrom=varnish@%i.service
 After=varnish@%i.service
 
 [Service]

--- a/service-files/wp-notifier-sidekick@.service
+++ b/service-files/wp-notifier-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Wordpress Notifier Sidekick
 PartOf=wp-notifier@%i.service
+ReloadPropagatedFrom=wp-notifier@%i.service
 After=wp-notifier@%i.service
 
 [Service]

--- a/service-files/wp-transformer-sidekick@.service
+++ b/service-files/wp-transformer-sidekick@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=wp-transformer Sidekick
 PartOf=wp-transformer@%i.service
+ReloadPropagatedFrom=wp-transformer@%i.service
 After=wp-transformer@%i.service
 
 [Service]

--- a/service-files/zookeeper-sidekick.service
+++ b/service-files/zookeeper-sidekick.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Zookeeper Sidekick
 PartOf=zookeeper.service
+ReloadPropagatedFrom=zookeeper.service
 After=zookeeper.service
 
 [Service]


### PR DESCRIPTION
This fixes the bug where once main service is stopped and sidekicks stop
along with it, once main service it restarted, sidekick remains dead.
ReloadPropagatedFrom ensures that the reload of the main service is
propogated to the sidekick