### PR TITLE
Externalise splunk forwarder images to dockerhub

### DIFF
--- a/service-files/splunk-forwarder.service
+++ b/service-files/splunk-forwarder.service
@@ -10,12 +10,12 @@ ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-filter > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-http > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-filter > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-http > /dev/null 2>&1'
-ExecStartPre=/usr/bin/docker pull up-registry.ft.com/coco/coco-splunk-http-forwarder
+ExecStartPre=/usr/bin/docker pull angelx/coco-splunk-http-forwarder
 ExecStartPre=/usr/bin/docker pull coco/coco-logfilter
 ExecStart=/bin/bash -c "\
   export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_url); \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
-  /usr/bin/journalctl -a -f --since=now --output=json | docker run -i --env=ENV=$ENV --rm --name %p-filter coco/coco-logfilter | docker run -i --rm --name %p-http --env=\"FORWARD_URL=$FORWARD_URL\" up-registry.ft.com/coco/coco-splunk-http-forwarder"
+  /usr/bin/journalctl -a -f --since=now --output=json | docker run -i --env=ENV=$ENV --rm --name %p-filter coco/coco-logfilter | docker run -i --rm --name %p-http --env=\"FORWARD_URL=$FORWARD_URL\" angelx/coco-splunk-http-forwarder"
 ExecStop=/bin/bash -c "/usr/bin/docker stop -t 3 %p-filter && /usr/bin/docker stop -t 3 %p-http"
 Restart=on-failure
 RestartSec=60


### PR DESCRIPTION
This doesn't work being in up-registry and registry itself uses the same
image. Reason its angelx and not coco, is that there is currently an
issue with dockerhub that is preventing us from deleting the coco
automated build. And the build won't work. So temp work around, putting
it on my account