### PR TITLE
Upgrade to a version that is based on new dwbase (pre-prod)

### DIFF
--- a/services-pre-prod.yaml
+++ b/services-pre-prod.yaml
@@ -24,7 +24,7 @@ services:
     count: 2
   - name: binary-ingester@.service
     uri: https://raw.githubusercontent.com/Financial-Times/fleet/pre-prod/service-files/binary-ingester@.service
-    version: v44
+    version: v45
     count: 2
   - name: binary-ingester-sidekick@.service
     uri: https://raw.githubusercontent.com/Financial-Times/fleet/pre-prod/service-files/binary-ingester-sidekick@.service


### PR DESCRIPTION
This uses a new dwbase in dockerhub which has no ft deps in it. Also, we
use official alpine openjdk8.