### PR TITLE
Adding mongo-backup service, timer and service definition

### DIFF
--- a/service-files/mongo-backup.service
+++ b/service-files/mongo-backup.service
@@ -1,0 +1,52 @@
+[Unit]
+Description=Job to backup mongo DB data files to S3
+
+[Service]
+# process will be short-lived and that systemd should wait for the process to
+# exit before continuing on with other units.
+Type=oneshot
+
+Environment="DOCKER_APP_VERSION=latest"
+
+# should start up instantly, so start timeout can be 0
+TimeoutStartSec=0
+
+# let Docker remove work correctly.
+KillMode=none
+
+# stop already running instance
+ExecStartPre=-/usr/bin/docker kill %p
+
+# remove existing instance
+ExecStartPre=-/usr/bin/docker rm %p
+
+ExecStart=/bin/sh -c "\
+    MONGODB_PORT=$(docker ps | grep mongodb | awk '{ print $1 }' | xargs -i docker port '{}' 27017 | cut -d':' -f2); \
+    MONGODB_HOST=$HOSTNAME; \
+    AWS_ACCESS_KEY=$(/usr/bin/etcdctl get /ft/_credentials/aws/aws_access_key_id);\
+    AWS_SECRET_KEY=$(/usr/bin/etcdctl get /ft/_credentials/aws/aws_secret_access_key); \
+    BUCKET_NAME=$(/usr/bin/etcdctl get /ft/config/mongo-backup/bucket); \
+    DATA_FOLDER=$(/usr/bin/etcdctl get /ft/config/mongo-backup/data_folder); \
+    S3_DOMAIN=$(/usr/bin/etcdctl get /ft/config/mongo-backup/s3_domain); \
+    ENV_TAG=$(usr/bin/etcdctl get /ft/config/environment_tag); \
+     /usr/bin/docker run --rm --name %p \
+        -e MONGODB_PORT=$MONGODB_PORT \
+        -e MONGODB_HOST=$MONGODB_HOST \
+        -e AWS_ACCESS_KEY=$AWS_ACCESS_KEY \
+        -e AWS_SECRET_KEY=$AWS_SECRET_KEY \
+        -e BUCKET_NAME=$BUCKET_NAME \
+        -e DATA_FOLDER=$DATA_FOLDER \
+        -e S3_DOMAIN=$S3_DOMAIN \
+        -e ENV_TAG=$ENV_TAG \
+        -v /vol/mongodb:$DATA_FOLDER \
+        up-registry.ft.com/coco/mongodb-backup:$DOCKER_APP_VERSION; "
+
+Nice=10
+
+[Install]
+# this sets user-level
+WantedBy=multi-user.target
+
+[X-Fleet]
+# we only want this to run on mongo machines
+MachineMetadata=host_type=persistent

--- a/service-files/mongo-backup.timer
+++ b/service-files/mongo-backup.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Runs the mongo backup job
+
+[Timer]
+OnCalendar=11:00
+
+[Install]
+WantedBy=timers.target
+
+[X-Fleet]
+MachineOf=mongo-backup.service
+

--- a/services.yaml
+++ b/services.yaml
@@ -120,8 +120,7 @@ services:
   - name: mongodb-all.service
     uri: https://raw.githubusercontent.com/Financial-Times/up-service-files/master/service-files/mongodb-all.service
   - name: mongo-backup.service
-    uri: https://raw.githubusercontent.com/Financial-Times/fleet/pre-prod/service-files/mongo-backup.service
+    uri: https://raw.githubusercontent.com/Financial-Times/fleet/master/service-files/mongo-backup.service
     desiredState: loaded
   - name: mongo-backup.timer
-    uri: https://raw.githubusercontent.com/Financial-Times/fleet/pre-prod/service-files/mongo-backup.timer
-
+    uri: https://raw.githubusercontent.com/Financial-Times/fleet/master/service-files/mongo-backup.timer

--- a/services.yaml
+++ b/services.yaml
@@ -119,4 +119,9 @@ services:
     uri: https://raw.githubusercontent.com/Financial-Times/fleet/master/service-files/image-cleaner.timer
   - name: mongodb-all.service
     uri: https://raw.githubusercontent.com/Financial-Times/up-service-files/master/service-files/mongodb-all.service
+  - name: mongo-backup.service
+    uri: https://raw.githubusercontent.com/Financial-Times/fleet/pre-prod/service-files/mongo-backup.service
+    desiredState: loaded
+  - name: mongo-backup.timer
+    uri: https://raw.githubusercontent.com/Financial-Times/fleet/pre-prod/service-files/mongo-backup.timer
 


### PR DESCRIPTION
* same service, timer and definition as on the `pre-prod` branch.
* I left the schedule the same as in `pre-prod` so we're here to see it happen. AFAIK we will only run this for a few days anyway. 
* added necessary data in `etcd` in prod as well