### PR TITLE
Unschedule skydns, currently not used by anything

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -69,7 +69,6 @@ services:
   - name: kafka.service
   - name: zookeeper.service
   - name: splunk-forwarder.service
-  - name: skydns.service
   - name: vulcan.service
   - name: methodeapi-endpoint.service
   - name: diamond.service


### PR DESCRIPTION
Leaving the unit file in, in case we want to use it for anything in the
future