### PR TITLE
added restorage instance running on mongo

### DIFF
--- a/restorage-mongo-sidekick@.service
+++ b/restorage-mongo-sidekick@.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Restorage mongodb sidekick
+BindsTo=restorage-mongo@%i.service
+After=restorage-mongo@%i.service
+
+[Service]
+ExecStartPre=/bin/sh -c "\
+  etcdctl set   /ft/services/restorage-mongo/healthcheck     true \
+  etcdctl mkdir /ft/services/restorage-mongo/servers
+ExecStart=/bin/sh -c "\
+   while true; do \
+    export PORT=$(echo $(/usr/bin/docker port restorage-mongo-%i 8080) | cut -d':' -f2); \
+    etcdctl set /ft/services/restorage-mongo/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
+    sleep 120; \
+  done"
+ExecStop=/usr/bin/etcdctl rm /ft/services/restorage-mongo/servers/%i
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=restorage-mongo@%i.service

--- a/restorage-mongo@.service
+++ b/restorage-mongo@.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=UP REST Storage - Mongodb
+After=docker.service kafka.service
+Requires=docker.service
+Wants=mongodb-sidekick@%i.service
+
+[Service]
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove
+# work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
+ExecStartPre=/usr/bin/docker pull coco/up-restorage
+
+ExecStart=/bin/bash -c 'export MONGOS=$((for i in $( etcdctl ls /ft/config/mongodb/) ; do echo -n $(etcdctl get $i/host):$(etcdctl get $i/port), ; done;) |  sed s/,$//) \
+    && /usr/bin/docker run --rm --name %p-%i -P coco/up-restorage /bin/bash -c "/up-restorage --id-map=organisations:uuid,content:uuid mongo --dbname=upp-store $MONGOS"'
+ExecStop=/usr/bin/docker stop -t 3 %p-%i
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=%p@*.service

--- a/services.yaml
+++ b/services.yaml
@@ -76,6 +76,10 @@ services:
   - name: image-cleaner.service
   - name: image-cleaner.timer
   - name: mongodb-all.service
+  - name: restorage-mongo@.service
+    count: 1
+  - name: restorage-mongo-sidekick@.service
+    count: 1
   - name: mongo-backup.service
     desiredState: loaded
   - name: mongo-backup.timer


### PR DESCRIPTION
This adds an instance of up-restorage to production, configured to point at mongodb.  Among other things, this gives a nice way to stream individual collections of data out of mongodb via curl, which can then (for example) be piped into other clusters, or into other restorage backends (e.g, elasticsearch)

Note that this app is single instance and not explicitly monitored etc at the moment as it's currently more of an operational tool than anything else.
