### PR TITLE
Explicitly turn off docker logging for filter and http-forwarder

### DIFF
--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -15,7 +15,7 @@ ExecStartPre=/usr/bin/docker pull coco/coco-logfilter
 ExecStart=/bin/bash -c "\
   export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_url); \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
-  /usr/bin/journalctl -a -f --since=now --output=json | docker run -i --env=ENV=$ENV --rm --name %p-filter coco/coco-logfilter | docker run -i --rm --name %p-http --env=\"FORWARD_URL=$FORWARD_URL\" coco/coco-splunk-http-forwarder"
+  /usr/bin/journalctl -a -f --since=now --output=json | docker run -i --log-driver=none --env=ENV=$ENV --rm --name %p-filter coco/coco-logfilter | docker run -i --log-driver=none --rm --name %p-http --env=\"FORWARD_URL=$FORWARD_URL\" coco/coco-splunk-http-forwarder"
 ExecStop=/bin/bash -c "/usr/bin/docker stop -t 3 %p-filter && /usr/bin/docker stop -t 3 %p-http"
 Restart=on-failure
 RestartSec=60


### PR DESCRIPTION
As it currently stands stdout is logged to a json file in
`/var/lib/docker/containers` and can consume all FS space. Logs are
already going into journald by virtue of process being wrapped in
`systemd` these however are managed and will not consume ALL space.