### PR TITLE
Standardizing mongo backup config

### DIFF
--- a/mongo-backup.service
+++ b/mongo-backup.service
@@ -25,9 +25,9 @@ ExecStart=/bin/sh -c "\
     MONGODB_HOST=$HOSTNAME; \
     AWS_ACCESS_KEY=$(/usr/bin/etcdctl get /ft/_credentials/aws/aws_access_key_id);\
     AWS_SECRET_KEY=$(/usr/bin/etcdctl get /ft/_credentials/aws/aws_secret_access_key); \
-    BUCKET_NAME=$(/usr/bin/etcdctl get /ft/config/mongo-backup/bucket); \
-    DATA_FOLDER=$(/usr/bin/etcdctl get /ft/config/mongo-backup/data_folder); \
-    S3_DOMAIN=$(/usr/bin/etcdctl get /ft/config/mongo-backup/s3_domain); \
+    BUCKET_NAME=com.ft.coco-mongo-backup.prod; \
+    DATA_FOLDER=/data/db; \
+    S3_DOMAIN=s3-eu-west-1.amazonaws.com; \
     ENV_TAG=$(usr/bin/etcdctl get /ft/config/environment_tag); \
      /usr/bin/docker run --rm --name %p \
         -e MONGODB_PORT=$MONGODB_PORT \


### PR DESCRIPTION
* read the bucket, data dir, and s3 domain from the service file instead of etcd
* the data dir and s3 domain are the same in all environments, so no reason to have them in etcd
* to simplify the configuration, we can keep all backups in the same bucket, as the backup file names are suffixed with the environment
* otherwise, to automate things, we would either have to dynamically build the bucket name in the provisioner
 * we currently have 1 bucket for pre-prod, 1 bucket for prod, and 2 prod envs
 * the other option is to manually add the values after the provisioner is done, which is not desirable