### PR TITLE
Make sure we delete the node before creating a record

### DIFF
--- a/tunnel-registrator.service
+++ b/tunnel-registrator.service
@@ -14,7 +14,7 @@ ExecStart=/bin/sh -c " \
   KONSTRUCTOR_DNS_ENDPOINT=https://konstructor.ft.com/v1/dns/; \
   PUBLIC_IP=$(curl -s 169.254.169.254/latest/meta-data/public-ipv4); \
   ((`curl -s -L -w \"%{http_code}\" -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/delete?zone=ft.com&name=$ENV-tunnel-up\" -o /dev/null` == 200)) \
-  && curl -s -L -X POST -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/create?zone=ft.com&name=$ENV-tunnel-up&rdata=$PUBLIC_IP&ttl=600\";"
+  && ((`curl -s -L -w \"%{http_code}\" -X POST -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/create?zone=ft.com&name=$ENV-tunnel-up&rdata=$PUBLIC_IP&ttl=600\" -o /dev/null` == 200));"
 
 [Install]
 WantedBy=multi-user.target

--- a/tunnel-registrator.service
+++ b/tunnel-registrator.service
@@ -13,8 +13,8 @@ ExecStart=/bin/sh -c " \
   KONSTRUCTOR_API_KEY=$(etcdctl get /ft/_credentials/konstructor/api-key); \
   KONSTRUCTOR_DNS_ENDPOINT=https://konstructor.ft.com/v1/dns/; \
   PUBLIC_IP=$(curl -s 169.254.169.254/latest/meta-data/public-ipv4); \
-  curl -s -L -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/delete?zone=ft.com&name=$ENV-tunnel-up\"; \
-  curl -s -L -X POST -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/create?zone=ft.com&name=$ENV-tunnel-up&rdata=$PUBLIC_IP&ttl=600\";"
+  curl -s -L -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/delete?zone=ft.com&name=$ENV-tunnel-up\" \
+  && curl -s -L -X POST -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/create?zone=ft.com&name=$ENV-tunnel-up&rdata=$PUBLIC_IP&ttl=600\";"
 
 [Install]
 WantedBy=multi-user.target

--- a/tunnel-registrator.service
+++ b/tunnel-registrator.service
@@ -13,7 +13,7 @@ ExecStart=/bin/sh -c " \
   KONSTRUCTOR_API_KEY=$(etcdctl get /ft/_credentials/konstructor/api-key); \
   KONSTRUCTOR_DNS_ENDPOINT=https://konstructor.ft.com/v1/dns/; \
   PUBLIC_IP=$(curl -s 169.254.169.254/latest/meta-data/public-ipv4); \
-  curl -s -L -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/delete?zone=ft.com&name=$ENV-tunnel-up\" \
+  ((`curl -s -L -w \"%{http_code}\" -X DELETE -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/delete?zone=ft.com&name=$ENV-tunnel-up\" -o /dev/null` == 200)) \
   && curl -s -L -X POST -H \"Content-Length: 0\" -H \"Accept: application/json\" -H \"Authorization: Basic $KONSTRUCTOR_API_KEY\" \"$KONSTRUCTOR_DNS_ENDPOINT/create?zone=ft.com&name=$ENV-tunnel-up&rdata=$PUBLIC_IP&ttl=600\";"
 
 [Install]


### PR DESCRIPTION
Konstructor will append a record to the node if one already exists. What
we want is to guarantee replacement. This will make the service fail if
we were unable to delete AND create an entry, making the operation
atomic