### PR TITLE
Implement short heartbeats for read services

### DIFF
--- a/api-policy-component-sidekick@.service
+++ b/api-policy-component-sidekick@.service
@@ -8,10 +8,10 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/services/api-policy-component/healthcheck true; \
   etcdctl mkdir /ft/services/api-policy-component/servers; \
   etcdctl set /ft/healthcheck/api-policy-component-%i /__health; \
+  PORT=$(/usr/bin/docker port api-policy-component-%i 8080 | cut -d':' -f2); \
   while true; do \
-    PORT=$(/usr/bin/docker port api-policy-component-%i 8080 | cut -d':' -f2); \
-    etcdctl set /ft/services/api-policy-component/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
-    sleep 120; \
+    etcdctl set /ft/services/api-policy-component/servers/%i "http://$HOSTNAME:$PORT" --ttl 5; \
+    sleep 4; \
   done"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/api-policy-component/servers/%i

--- a/api-policy-component-sidekick@.service
+++ b/api-policy-component-sidekick@.service
@@ -10,7 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/healthcheck/api-policy-component-%i /__health; \
   PORT=$(/usr/bin/docker port api-policy-component-%i 8080 | cut -d':' -f2); \
   while true; do \
-    etcdctl set /ft/services/api-policy-component/servers/%i "http://$HOSTNAME:$PORT" --ttl 5; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq .checks[].ok | grep -q false || etcdctl set /ft/services/api-policy-component/servers/%i "http://%H:$PORT" --ttl 5; \
     sleep 4; \
   done"
 

--- a/document-store-api-sidekick@.service
+++ b/document-store-api-sidekick@.service
@@ -10,11 +10,11 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/healthcheck/document-store-api-%i /__health; \
   etcdctl set /vulcand/frontends/public-services-content/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}.*`) && Host(`public-services`)\"}'; \
   etcdctl set /vulcand/frontends/public-services-lists/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/lists/.*`) && Host(`public-services`)\"}'; \
+  PORT=$(/usr/bin/docker port document-store-api-%i 8080 | cut -d':' -f2); \
   while true; do \
-      PORT=$(/usr/bin/docker port document-store-api-%i 8080 | cut -d':' -f2); \
-      etcdctl set /ft/services/document-store-api/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
-      sleep 120; \
-    done"
+    etcdctl set /ft/services/document-store-api/servers/%i "http://$HOSTNAME:$PORT" --ttl 5; \
+    sleep 4; \
+  done"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/document-store-api/servers/%i
 

--- a/document-store-api-sidekick@.service
+++ b/document-store-api-sidekick@.service
@@ -12,7 +12,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/frontends/public-services-lists/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/lists/.*`) && Host(`public-services`)\"}'; \
   PORT=$(/usr/bin/docker port document-store-api-%i 8080 | cut -d':' -f2); \
   while true; do \
-    etcdctl set /ft/services/document-store-api/servers/%i "http://$HOSTNAME:$PORT" --ttl 5; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq .checks[].ok | grep -q false || etcdctl set /ft/services/document-store-api/servers/%i "http://%H:$PORT" --ttl 5; \
     sleep 4; \
   done"
 


### PR DESCRIPTION
This is part of the effort to create a read endpoint healthcheck which
would monitor availability of at least one service being available