### PR TITLE
Add middleware to redirect content to content-read endpoint.

### DIFF
--- a/document-store-api-sidekick@.service
+++ b/document-store-api-sidekick@.service
@@ -9,6 +9,7 @@ ExecStart=/bin/sh -c "\
   etcdctl mkdir /ft/services/document-store-api/servers; \
   etcdctl set /ft/healthcheck/document-store-api-%i /__health; \
   etcdctl set /vulcand/frontends/public-services-content/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}.*`) && Host(`public-services`)\"}'; \
+  etcdctl set /vulcand/frontends/public-services-content/middlewares/rewrite '{\"Id\":\"rewrite\", \"Type\":\"rewrite\", \"Priority\":1, \"Middleware\": {\"Regexp\":\"/content/(.*)\", \"Replacement\":\"/content-read/$1\"}}'; \
   etcdctl set /vulcand/frontends/public-services-lists/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/lists/.*`) && Host(`public-services`)\"}'; \
   etcdctl set /vulcand/frontends/varnish-public-content-endpoint/frontend '{\"Type\":\"http\", \"BackendId\":\"vcb-varnish\", \"Route\":\"PathRegexp(`/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}.*`) && MethodRegexp(`GET|HEAD`) && HeaderRegexp(`X-VarnishPassThrough`, `^$`)\"}'; \
   etcdctl set /vulcand/frontends/varnish-public-lists-endpoint/frontend '{\"Type\":\"http\", \"BackendId\":\"vcb-varnish\", \"Route\":\"PathRegexp(`/lists/.*`) && MethodRegexp(`GET|HEAD`) && HeaderRegexp(`X-VarnishPassThrough`, `^$`)\"}'; \


### PR DESCRIPTION
The redirect is set at "public-services" level for doc-store-api. Tested in XP. 