### PR TITLE
bump pam version

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -100,7 +100,7 @@ services:
 - name: publish-availability-monitor-sidekick@.service
   count: 1
 - name: publish-availability-monitor@.service
-  version: 0.16.0
+  version: 0.16.1
   count: 1
 - name: restorage-mongo-sidekick@.service
   count: 1


### PR DESCRIPTION
contains timestamp fixes, reverting non-ft source content publish check, etc.