### PR TITLE
Register read dns

### DIFF
--- a/document-store-api-sidekick@.service
+++ b/document-store-api-sidekick@.service
@@ -10,8 +10,6 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/healthcheck/document-store-api-%i /__health; \
   etcdctl set /vulcand/frontends/public-services-content/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}.*`) && Host(`public-services`)\"}'; \
   etcdctl set /vulcand/frontends/public-services-lists/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/lists/.*`) && Host(`public-services`)\"}'; \
-  etcdctl set /vulcand/frontends/varnish-public-content-endpoint/frontend '{\"Type\":\"http\", \"BackendId\":\"vcb-varnish\", \"Route\":\"PathRegexp(`/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}.*`) && MethodRegexp(`GET|HEAD`) && HeaderRegexp(`X-VarnishPassThrough`, `^$`)\"}'; \
-  etcdctl set /vulcand/frontends/varnish-public-lists-endpoint/frontend '{\"Type\":\"http\", \"BackendId\":\"vcb-varnish\", \"Route\":\"PathRegexp(`/lists/.*`) && MethodRegexp(`GET|HEAD`) && HeaderRegexp(`X-VarnishPassThrough`, `^$`)\"}'; \
   while true; do \
       PORT=$(/usr/bin/docker port document-store-api-%i 8080 | cut -d':' -f2); \
       etcdctl set /ft/services/document-store-api/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
@@ -22,3 +20,4 @@ ExecStop=/usr/bin/etcdctl rm /ft/services/document-store-api/servers/%i
 
 [X-Fleet]
 MachineOf=document-store-api@%i.service
+

--- a/elb-dns-registrator.service
+++ b/elb-dns-registrator.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Registers ELB CNAME in DYN via Konstructor
+Description=Registering ELB CNAME in DYN via Konstructor
 
 [Service]
 Type=oneshot
@@ -9,7 +9,8 @@ Environment="DOCKER_APP_VERSION=latest"
 # work correctly.
 KillMode=none
 ExecStart=/bin/sh -c " \
-  docker run --rm --name %p --env=\"ETCD_PEERS=http://%H:2379\" coco/coco-elb-dns-registrator:$DOCKER_APP_VERSION"
+  ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
+  docker run --rm --name %p --env=\"ETCD_PEERS=http://%H:2379\" --env=\"DOMAINS=$ENV-up,$ENV-up-read\" coco/coco-elb-dns-registrator:$DOCKER_APP_VERSION"
 
 [Install]
 WantedBy=multi-user.target

--- a/services.yaml
+++ b/services.yaml
@@ -40,7 +40,7 @@ services:
   version: v34
   count: 2
 - name: elb-dns-registrator.service
-  version: v1.0.0
+  version: v2.0.0
 - name: elb-presence.service
 - name: fleet-unit-healthcheck-sidekick.service
 - name: fleet-unit-healthcheck.service

--- a/services.yaml
+++ b/services.yaml
@@ -120,11 +120,6 @@ services:
 - name: system-healthcheck-sidekick.service
 - name: system-healthcheck.service
 - name: tunnel-registrator.service
-- name: varnish-sidekick@.service
-  count: 1
-- name: varnish@.service
-  version: v35
-  count: 1
 - name: vulcan-config-builder.service
   version: v5
 - name: vulcan.service

--- a/varnish-sidekick@.service
+++ b/varnish-sidekick@.service
@@ -5,17 +5,15 @@ After=varnish@%i.service
 
 [Service]
 ExecStart=/bin/sh -c "\
-  etcdctl set   /ft/services/varnish/healthcheck true; \
-  etcdctl mkdir /ft/services/varnish/servers; \
-  etcdctl set /ft/healthcheck/varnish-%i /__health; \
+  export VARNISH_IP=$HOSTNAME; \
   while true; do \
-    export PORT=$(/usr/bin/docker port varnish-%i 80 | cut -d':' -f2); \
-    etcdctl set /ft/services/varnish/servers/%i http://$HOSTNAME:$PORT --ttl 600; \
+    export VARNISH_PORT=$(/usr/bin/docker port varnish-%i 80 | cut -d':' -f2); \
+    etcdctl set /services/varnish/%i/host $VARNISH_IP --ttl 60; \
+    etcdctl set /services/varnish/%i/port $VARNISH_PORT --ttl 60; \
     sleep 45; \
   done"
-ExecStop=/bin/sh -c "\
-  etcdctl rm /ft/services/varnish/servers/%i; \
-  etcdctl rm /vulcand/frontends/varnish-public/frontend"
+ExecStop=/usr/bin/etcdctl rm /services/varnish@%i
 
 [X-Fleet]
 MachineOf=varnish@%i.service
+


### PR DESCRIPTION
* Using new version of elb-dns-registrator to support multiple domain creation - $ENV-up (current) and $ENV-up-read (for read endpoints)

Additional changes from pre-prod:
* Fixing varnish's Host regex
* Versions of doc store api and api policy component. Rename opening to openingXML and apply INCLUDE_RICH_CONTENT policy to openingXML
* Bump PAM version. Skip checking live content from notifications endpoint
* Deploy version of SIPM that runs the application process as PID 1 in
attempt to fix the issue with orphaned containers