### PR TITLE
Register read DNS

### DIFF
--- a/elb-dns-registrator.service
+++ b/elb-dns-registrator.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Registers ELB CNAME in DYN via Konstructor
+Description=Registering ELB CNAME in DYN via Konstructor
 
 [Service]
 Type=oneshot
@@ -9,7 +9,8 @@ Environment="DOCKER_APP_VERSION=latest"
 # work correctly.
 KillMode=none
 ExecStart=/bin/sh -c " \
-  docker run --rm --name %p --env=\"ETCD_PEERS=http://%H:2379\" coco/coco-elb-dns-registrator:$DOCKER_APP_VERSION"
+  ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
+  docker run --rm --name %p --env=\"ETCD_PEERS=http://%H:2379\" --env=\"DOMAINS=$ENV-up,$ENV-up-read\" coco/coco-elb-dns-registrator:$DOCKER_APP_VERSION"
 
 [Install]
 WantedBy=multi-user.target

--- a/services.yaml
+++ b/services.yaml
@@ -40,7 +40,7 @@ services:
   version: v34
   count: 2
 - name: elb-dns-registrator.service
-  version: v1.0.0
+  version: v2.0.0
 - name: elb-presence.service
 - name: fleet-unit-healthcheck-sidekick.service
 - name: fleet-unit-healthcheck.service


### PR DESCRIPTION
* Using new version of elb-dns-registrator to support multiple domain creation - $ENV-up (current) and $ENV-up-read (for read endpoints)