### PR TITLE
Add v1 suggestor

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -82,6 +82,10 @@ services:
 - name: nativerw@.service
   version: v35
   count: 2
+- name: neo4j-sidekick@.service
+  count: 1
+- name: neo4j@.service
+  count: 1
 - name: notifications-ingester-sidekick@.service
   count: 2
 - name: notifications-ingester@.service
@@ -115,6 +119,11 @@ services:
 - name: system-healthcheck-sidekick.service
 - name: system-healthcheck.service
 - name: tunnel-registrator.service
+- name: v1-suggestor-sidekick@.service
+  count: 2
+- name: v1-suggestor@.service
+  version: v0.0.1
+  count: 2
 - name: vulcan-config-builder.service
   version: v5
 - name: vulcan.service
@@ -124,7 +133,3 @@ services:
   version: v38
   count: 2
 - name: zookeeper.service
-- name: neo4j@.service
-  count: 1
-- name: neo4j-sidekick@.service
-  count: 1

--- a/v1-suggestor-sidekick@.service
+++ b/v1-suggestor-sidekick@.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=V1 Metadata Suggestor sidekick
+BindsTo=v1-suggestor@%i.service
+After=v1-suggestor@%i.service
+
+[Service]
+ExecStart=/bin/sh -c "\
+  etcdctl set   /ft/services/v1-suggestor/healthcheck     true; \
+  etcdctl mkdir /ft/services/v1-suggestor/servers; \
+  etcdctl set /ft/healthcheck/v1-suggestor-%i /__health; \
+  PORT=$(/usr/bin/docker port v1-suggestor-%i 8080 | cut -d':' -f2); \
+  while true; do \
+    etcdctl set /ft/services/v1-suggestor/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
+    sleep 120; \
+  done"
+ExecStop=/usr/bin/etcdctl rm /ft/services/v1-suggestor/servers/%i
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=v1-suggestor@%i.service
+

--- a/v1-suggestor@.service
+++ b/v1-suggestor@.service
@@ -16,7 +16,7 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker pull coco/v1-suggestor:$DOCKER_APP_VE
 ExecStart=/bin/bash -c '\
   	export ENVIRONMENT_TAG=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
 	docker run --rm --name %p-%i -p 8080 \
-	--env "SRC_ADDR=http://%H:8080,http://%H:8080" \
+	--env "SRC_ADDR=http://%H:8080" \
 	--env "SRC_GROUP=v1Suggestor" \
 	--env "SRC_TOPIC=NativeCmsMetadataPublicationEvents" \
 	--env "SRC_QUEUE=kafka" \

--- a/v1-suggestor@.service
+++ b/v1-suggestor@.service
@@ -16,7 +16,7 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker pull coco/v1-suggestor:$DOCKER_APP_VE
 ExecStart=/bin/bash -c '\
   	export ENVIRONMENT_TAG=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
 	docker run --rm --name %p-%i -p 8080 \
-	--env "SRC_ADDR=http://%H:8080," \
+	--env "SRC_ADDR=http://%H:8080,http://%H:8080," \
 	--env "SRC_GROUP=v1Suggestor" \
 	--env "SRC_TOPIC=NativeCmsMetadataPublicationEvents" \
 	--env "SRC_QUEUE=kafka" \

--- a/v1-suggestor@.service
+++ b/v1-suggestor@.service
@@ -30,3 +30,5 @@ ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure
 RestartSec=60
 
+[X-Fleet]
+Conflicts=v1-suggestor@*.service

--- a/v1-suggestor@.service
+++ b/v1-suggestor@.service
@@ -9,10 +9,9 @@ TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
-ExecStartPre=/bin/bash -c '/usr/bin/docker pull coco/v1-suggestor:$DOCKER_APP_VERSION'
-
+ExecStartPre=-/bin/bash -c 'docker kill %p-%i > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c 'docker rm %p-%i > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker history coco/v1-suggestor:$DOCKER_APP_VERSION > /dev/null 2>&1 || docker pull coco/v1-suggestor:$DOCKER_APP_VERSION'
 ExecStart=/bin/bash -c '\
   	export ENVIRONMENT_TAG=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
 	docker run --rm --name %p-%i -p 8080 \

--- a/v1-suggestor@.service
+++ b/v1-suggestor@.service
@@ -16,7 +16,7 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker pull coco/v1-suggestor:$DOCKER_APP_VE
 ExecStart=/bin/bash -c '\
   	export ENVIRONMENT_TAG=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
 	docker run --rm --name %p-%i -p 8080 \
-	--env "SRC_ADDR=http://%H:8080,http://%H:8080," \
+	--env "SRC_ADDR=[http://%H:8080]" \
 	--env "SRC_GROUP=v1Suggestor" \
 	--env "SRC_TOPIC=NativeCmsMetadataPublicationEvents" \
 	--env "SRC_QUEUE=kafka" \

--- a/v1-suggestor@.service
+++ b/v1-suggestor@.service
@@ -16,7 +16,7 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker pull coco/v1-suggestor:$DOCKER_APP_VE
 ExecStart=/bin/bash -c '\
   	export ENVIRONMENT_TAG=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
 	docker run --rm --name %p-%i -p 8080 \
-	--env "SRC_ADDR=[http://%H:8080]" \
+	--env "SRC_ADDR=http://%H:8080,http://%H:8080" \
 	--env "SRC_GROUP=v1Suggestor" \
 	--env "SRC_TOPIC=NativeCmsMetadataPublicationEvents" \
 	--env "SRC_QUEUE=kafka" \

--- a/v1-suggestor@.service
+++ b/v1-suggestor@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=V1 Metadata Suggester
+Description=V1 Metadata Suggestor
 After=docker.service
 Requires=docker.service
 
@@ -16,7 +16,7 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker pull coco/v1-suggestor:$DOCKER_APP_VE
 ExecStart=/bin/bash -c '\
   	export ENVIRONMENT_TAG=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
 	docker run --rm --name %p-%i -p 8080 \
-	--env "SRC_ADDR=http://%H:8080" \
+	--env "SRC_ADDR=http://%H:8080," \
 	--env "SRC_GROUP=v1Suggestor" \
 	--env "SRC_TOPIC=NativeCmsMetadataPublicationEvents" \
 	--env "SRC_QUEUE=kafka" \

--- a/v1-suggestor@.service
+++ b/v1-suggestor@.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=V1 Metadata Suggester
+After=docker.service
+Requires=docker.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove
+# work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c '/usr/bin/docker pull coco/v1-suggestor:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/bash -c '\
+  	export ENVIRONMENT_TAG=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
+	docker run --rm --name %p-%i -p 8080 \
+	--env "SRC_ADDR=http://%H:8080" \
+	--env "SRC_GROUP=v1Suggestor" \
+	--env "SRC_TOPIC=NativeCmsMetadataPublicationEvents" \
+	--env "SRC_QUEUE=kafka" \
+	--env "SRC_CONCURRENT_PROCESSING=false" \
+	--env "DEST_ADDRESS=http://%H:8080" \
+	--env "DEST_TOPIC=ConceptSuggestions" \
+	--env "DEST_QUEUE=kafka" \
+	--env "ENVIRONMENT=coco-$ENVIRONMENT_TAG" \
+	coco/v1-suggestor:$DOCKER_APP_VERSION'
+
+ExecStop=/usr/bin/docker stop -t 3 %p-%i
+Restart=on-failure
+RestartSec=60
+


### PR DESCRIPTION
V1 suggestor is working in XP 

- it's getting the messages from the kafka queue
- generating concept suggestions
- putting concept suggestions on the right queue
- these concept suggestions are ignored by the v2-annotator because of the origin