### PR TITLE
Binary ingester v87. AutoCommit is turned on for consuming messages...

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: binary-ingester-sidekick@.service
   count: 2
 - name: binary-ingester@.service
-  version: v84
+  version: v87
   count: 2
 - name: binary-writer-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -14,6 +14,7 @@ services:
   count: 2
 - name: binary-ingester@.service
   version: v87
+  sequentialDeployment: true
   count: 2
 - name: binary-writer-sidekick@.service
   count: 2


### PR DESCRIPTION
Binary ingester v87. AutoCommit is turned on for consuming messages via the kafka http proxy.