### PR TITLE
Bumping content annotator to v18

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -192,7 +192,7 @@ services:
 - name: v1-content-annotator-sidekick@.service
   count: 2
 - name: v1-content-annotator@.service
-  version: v17
+  version: v18
   count: 2
 - name: v1-suggestor-sidekick@.service
   count: 2
@@ -207,7 +207,7 @@ services:
 - name: v2-content-annotator-sidekick@.service
   count: 2
 - name: v2-content-annotator@.service
-  version: v17
+  version: v18
   count: 2
 - name: varnish-sidekick@.service
   count: 2


### PR DESCRIPTION
* http://git.svc.ft.com/projects/CP/repos/content-annotator/pull-requests/9/overview
* tested in XP, works 
* try it on an v1-annotations-rw machine: curl -H "X-Request-Id: 123" localhost:32801/content/d798715a-e08d-11e5-bd34-4c13bb3472e1/annotations