### PR TITLE
Add platform version to content brands relationships

### DIFF
--- a/public-content-by-concept-api-sidekick@.service
+++ b/public-content-by-concept-api-sidekick@.service
@@ -8,6 +8,8 @@ ExecStart=/bin/sh -c "\
   etcdctl set   /ft/services/public-content-by-concept-api/healthcheck     true; \
   etcdctl mkdir /ft/services/public-content-by-concept-api/servers; \
   etcdctl set /ft/healthcheck/public-content-by-concept-api-%i/path /__health; \
+  etcdctl set /ft/healthcheck/public-content-by-concept-api-%i/categories read; \
+  etcdctl set /vulcand/frontends/public-services-content-by-concept/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-public-content-by-concept-api\", \"Route\": \"PathRegexp(``/content.*\?.*isAnnotatedBy=.*$`) && Host(`public-services`)\"}'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-content-by-concept-api-%i 8080 | cut -d':' -f2)`; \
     curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-content-by-concept-api/servers/%i http://%H:$PORT --ttl 5; \

--- a/public-content-by-concept-api-sidekick@.service
+++ b/public-content-by-concept-api-sidekick@.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Public Content by Concept API Service Sidekick
+BindsTo=public-content-by-concept-api@%i.service
+After=public-content-by-concept-api@%i.service
+
+[Service]
+ExecStart=/bin/sh -c "\
+  etcdctl set   /ft/services/public-content-by-concept-api/healthcheck     true; \
+  etcdctl mkdir /ft/services/public-content-by-concept-api/servers; \
+  etcdctl set /ft/healthcheck/public-content-by-concept-api-%i/path /__health; \
+  while true; do \
+    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-content-by-concept-api-%i 8080 | cut -d':' -f2)`; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-content-by-concept-api/servers/%i http://%H:$PORT --ttl 5; \
+    sleep 4; \
+  done"
+
+ExecStop=/usr/bin/etcdctl rm /ft/services/public-content-by-concept-api/servers/%i
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=public-content-by-concept-api@%i.service

--- a/public-content-by-concept-api-sidekick@.service
+++ b/public-content-by-concept-api-sidekick@.service
@@ -9,7 +9,7 @@ ExecStart=/bin/sh -c '\
   etcdctl mkdir /ft/services/public-content-by-concept-api/servers; \
   etcdctl set 	/ft/healthcheck/public-content-by-concept-api-%i/path 		/__health; \
   etcdctl set 	/ft/healthcheck/public-content-by-concept-api-%i/categories 	read; \
-  etcdctl set 	/vulcand/frontends/public-services-content-by-concept/frontend 	{"Type": "http", "BackendId": "vcb-public-content-by-concept-api", "Route": "PathRegexp(`/content.*\?.*isAnnotatedBy=.*$`) && Host(`public-services`)"}'; \
+Host(`public-services`)"}'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-content-by-concept-api-%i 8080 | cut -d':' -f2)`; \
     curl -s -H "Accept: application/json" 0.0.0.0:$PORT/__health | jq -e \'[.checks[].ok] | all\' 2>&1>/dev/null && etcdctl set /ft/services/public-content-by-concept-api/servers/%i http://%H:$PORT --ttl 5; \

--- a/public-content-by-concept-api-sidekick@.service
+++ b/public-content-by-concept-api-sidekick@.service
@@ -9,7 +9,7 @@ ExecStart=/bin/sh -c "\
   etcdctl mkdir /ft/services/public-content-by-concept-api/servers; \
   etcdctl set /ft/healthcheck/public-content-by-concept-api-%i/path /__health; \
   etcdctl set /ft/healthcheck/public-content-by-concept-api-%i/categories read; \
-  etcdctl set /vulcand/frontends/public-services-content-by-concept/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-public-content-by-concept-api\", \"Route\": \"PathRegexp(``/content.*\?.*isAnnotatedBy=.*$`) && Host(`public-services`)\"}'; \
+  etcdctl set /vulcand/frontends/public-services-content-by-concept/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-public-content-by-concept-api\", \"Route\": \"PathRegexp(`/content.*\?.*isAnnotatedBy=.*$`) && Host(`public-services`)\"}'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-content-by-concept-api-%i 8080 | cut -d':' -f2)`; \
     curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-content-by-concept-api/servers/%i http://%H:$PORT --ttl 5; \

--- a/public-content-by-concept-api-sidekick@.service
+++ b/public-content-by-concept-api-sidekick@.service
@@ -4,17 +4,17 @@ BindsTo=public-content-by-concept-api@%i.service
 After=public-content-by-concept-api@%i.service
 
 [Service]
-ExecStart=/bin/sh -c "\
-  etcdctl set   /ft/services/public-content-by-concept-api/healthcheck     true; \
+ExecStart=/bin/sh -c '\
+  etcdctl set	/ft/services/public-content-by-concept-api/healthcheck  	true; \
   etcdctl mkdir /ft/services/public-content-by-concept-api/servers; \
-  etcdctl set /ft/healthcheck/public-content-by-concept-api-%i/path /__health; \
-  etcdctl set /ft/healthcheck/public-content-by-concept-api-%i/categories read; \
-  etcdctl set /vulcand/frontends/public-services-content-by-concept/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-public-content-by-concept-api\", \"Route\": \"PathRegexp(`/content.*\?.*isAnnotatedBy=.*$`) && Host(`public-services`)\"}'; \
+  etcdctl set 	/ft/healthcheck/public-content-by-concept-api-%i/path 		/__health; \
+  etcdctl set 	/ft/healthcheck/public-content-by-concept-api-%i/categories 	read; \
+  etcdctl set 	/vulcand/frontends/public-services-content-by-concept/frontend 	{"Type": "http", "BackendId": "vcb-public-content-by-concept-api", "Route": "PathRegexp(`/content.*\?.*isAnnotatedBy=.*$`) && Host(`public-services`)"}'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-content-by-concept-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-content-by-concept-api/servers/%i http://%H:$PORT --ttl 5; \
+    curl -s -H "Accept: application/json" 0.0.0.0:$PORT/__health | jq -e \'[.checks[].ok] | all\' 2>&1>/dev/null && etcdctl set /ft/services/public-content-by-concept-api/servers/%i http://%H:$PORT --ttl 5; \
     sleep 4; \
-  done"
+  done'
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/public-content-by-concept-api/servers/%i
 Restart=on-failure

--- a/public-content-by-concept-api@.service
+++ b/public-content-by-concept-api@.service
@@ -9,15 +9,15 @@ Environment="DOCKER_APP_VERSION=latest"
 TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
-ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/public-content-by-concept-api:$DOCKER_APP_VERSION > /dev/null 2>&1 || /usr/bin/docker pull coco/public-content-by-concept-api:$DOCKER_APP_VERSION'
+ExecStartPre=-/bin/bash -c 'docker kill %p-%i > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c 'docker rm %p-%i > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker history coco/public-content-by-concept-api:$DOCKER_APP_VERSION > /dev/null 2>&1 || docker pull coco/public-content-by-concept-api:$DOCKER_APP_VERSION'
 
 ExecStart=/bin/sh -c '\
   export APP_PORT=8080; \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
   export NEO_HOST_PORT=$(/usr/bin/etcdctl get /ft/services/neo4j/servers/1); \
-  /usr/bin/docker run --rm --name %p-%i -p $APP_PORT --env "NEO_URL=$NEO_HOST_PORT/db/data" --env "APP_PORT=$APP_PORT" --env "GRAPHITE_ADDRESS=graphite.ft.com:2003" --env "GRAPHITE_PREFIX=coco.services.$ENV.public-content-by-concept-api.%i" --env "LOG_METRICS=false" --env "CACHE_DURATION=30s" coco/public-content-by-concept-api:$DOCKER_APP_VERSION;'
+  /usr/bin/docker run --rm --name %p-%i -p $APP_PORT -e NEO_URL=$NEO_HOST_PORT/db/data -e APP_PORT=$APP_PORT -e GRAPHITE_ADDRESS=graphite.ft.com:2003 -e GRAPHITE_PREFIX=coco.services.$ENV.public-content-by-concept-api.%i -e LOG_METRICS=false -e CACHE_DURATION=30s coco/public-content-by-concept-api:$DOCKER_APP_VERSION;'
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure
 RestartSec=60

--- a/public-content-by-concept-api@.service
+++ b/public-content-by-concept-api@.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Public Content By Concept API Service
+After=vulcan.service
+Requires=docker.service
+Wants=public-content-by-concept-api-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/public-content-by-concept-api:$DOCKER_APP_VERSION > /dev/null 2>&1 || /usr/bin/docker pull coco/public-content-by-concept-api:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/sh -c '\
+  export APP_PORT=8080; \
+  export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
+  export NEO_HOST_PORT=$(/usr/bin/etcdctl get /ft/services/neo4j/servers/1); \
+  /usr/bin/docker run --rm --name %p-%i -p $APP_PORT --env "NEO_URL=$NEO_HOST_PORT/db/data" --env "APP_PORT=$APP_PORT" --env "GRAPHITE_ADDRESS=graphite.ft.com:2003" --env "GRAPHITE_PREFIX=coco.services.$ENV.public-content-by-concept-api.%i" --env "LOG_METRICS=false" --env "CACHE_DURATION=30s" coco/public-content-by-concept-api:$DOCKER_APP_VERSION;'
+ExecStop=/usr/bin/docker stop -t 3 %p-%i
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=public-content-by-concept-api@*.service

--- a/services.yaml
+++ b/services.yaml
@@ -64,7 +64,7 @@ services:
 - name: content-rw-neo4j-sidekick@.service
   count: 2
 - name: content-rw-neo4j@.service
-  version: v0.0.24
+  version: v0.0.25
   count: 2
 - name: diamond.service
 - name: document-store-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -161,7 +161,7 @@ services:
 - name: public-content-by-concept-api-sidekick@.service
   count: 2
 - name: public-content-by-concept-api@.service
-  version: v0.0.1
+  version: v0.0.2
   count: 2
   sequentialDeployment: true
 - name: publish-availability-monitor-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -148,6 +148,12 @@ services:
   version: v0.0.4
   count: 2
   sequentialDeployment: true
+- name: public-content-by-concept-api-sidekick@.service
+  count: 2
+- name: public-content-by-concept-api@.service
+  version: v0.0.1
+  count: 2
+  sequentialDeployment: true
 - name: publish-availability-monitor-sidekick@.service
   count: 1
 - name: publish-availability-monitor@.service

--- a/services.yaml
+++ b/services.yaml
@@ -64,7 +64,7 @@ services:
 - name: content-rw-neo4j-sidekick@.service
   count: 2
 - name: content-rw-neo4j@.service
-  version: v0.0.23
+  version: v0.0.24
   count: 2
 - name: diamond.service
 - name: document-store-api-sidekick@.service


### PR DESCRIPTION
Bump of content-rw-neo4j version which pulls in the below changes

https://github.com/Financial-Times/content-rw-neo4j/commit/9f9f9b219e24d65073187c4be35a1f3b44cff935

- Added platformVersion property to all IS_CLASSIFIED_BY relationships between content and v2  brands.
- content-rw-neo4j returns 204 when content has no body.