### PR TITLE
Add platform version to content brands relationships2

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -64,7 +64,7 @@ services:
 - name: content-rw-neo4j-sidekick@.service
   count: 2
 - name: content-rw-neo4j@.service
-  version: v0.0.24
+  version: v0.0.25
   count: 2
 - name: diamond.service
 - name: document-store-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -64,7 +64,7 @@ services:
 - name: content-rw-neo4j-sidekick@.service
   count: 2
 - name: content-rw-neo4j@.service
-  version: v0.0.23
+  version: v0.0.24
   count: 2
 - name: diamond.service
 - name: document-store-api-sidekick@.service


### PR DESCRIPTION
Bump of content-rw-neo4j version which pulls in the below changes

Financial-Times/content-rw-neo4j@9f9f9b2 

-  Added platformVersion property to IS_CLASSIFIED_BY relationships between content and v2 brands.

- content-rw-neo4j returns 204 when content has no body.

