### PR TITLE
Re-promote content-importer v45, this time with service changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *coverage.*
 *.iml
 .idea/
+/.project

--- a/methode-content-importer@.service
+++ b/methode-content-importer@.service
@@ -17,7 +17,11 @@ ExecStartPre=/bin/bash -c 'docker pull up-registry.ft.com/coco/methode-content-i
 ExecStart=/bin/sh -c '\
   export BROKER_LIST=$(/usr/bin/etcdctl get /ft/config/kafka/ip):$(/usr/bin/etcdctl get /ft/config/kafka/port); \
   export CONSUMER_LIST=$(/usr/bin/etcdctl get /ft/config/zookeeper/ip):$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
-  /usr/bin/docker run --rm --name %p-%i -p 8080 -p 8081 --env "CONSUMER_LIST=$CONSUMER_LIST" --env "BROKER_LIST=$BROKER_LIST" --env "QUEUEPROXY_HOST=$HOSTNAME:8080" --env "NATIVERW_HOST=$HOSTNAME:8080" up-registry.ft.com/coco/methode-content-importer:$DOCKER_APP_VERSION'
+   /usr/bin/docker run --rm --name %p-%i -p 8080 -p 8081 --env "CONSUMER_LIST=$CONSUMER_LIST" --env "BROKER_LIST=$BROKER_LIST" \
+        --env "QUEUEPROXY_HOST=$HOSTNAME:8080" \
+        --env "NATIVERW_HOST=$HOSTNAME:8080" \
+        --env "TRANSFORMER_PROXY=$HOSTNAME:8080" \
+        up-registry.ft.com/coco/methode-content-importer:$DOCKER_APP_VERSION'
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure
 RestartSec=60

--- a/services.yaml
+++ b/services.yaml
@@ -117,7 +117,7 @@ services:
 - name: methode-content-importer-sidekick@.service
   count: 2
 - name: methode-content-importer@.service
-  version: v41
+  version: v45
   count: 2
 - name: methode-image-binary-transformer-sidekick@.service
   count: 2


### PR DESCRIPTION
The change to add the TRANSFORMER_PROXY environment variable was
previously missing from the content-importer service file. This branch
is for updating the content-importer only, so the value is not removed
from the ingesters at this point.