### PR TITLE
Making sure neo4j driver always connects to neo4j via vulcan.

### DIFF
--- a/neo4j-read-blue-sidekick@.service
+++ b/neo4j-read-blue-sidekick@.service
@@ -5,6 +5,7 @@ After=neo4j-blue@%i.service
 
 [Service]
 ExecStart=/bin/sh -c '\
+   etcdctl set /vulcand/backends/neo4j-read/backend \'{"Type": "http"}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
    etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \

--- a/neo4j-read-blue-sidekick@.service
+++ b/neo4j-read-blue-sidekick@.service
@@ -5,10 +5,10 @@ After=neo4j-blue@%i.service
 
 [Service]
 ExecStart=/bin/sh -c '\
-  etcdctl set /vulcand/backends/neo4j-read/backend \'{"Type": "http"}\'; \
-  etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)"}\'; \
-  etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
-  while true; do \
+   etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
+   etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
+   etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
+   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port neo4j-blue-%i 7474 | cut -d":" -f2)`; \
     etcdctl set /vulcand/backends/neo4j-read/servers/2 "{\\"url\\": \\"http://$HOSTNAME:$PORT\\"}" --ttl 5; \
     sleep 4; \

--- a/neo4j-read-red-sidekick@.service
+++ b/neo4j-read-red-sidekick@.service
@@ -4,15 +4,16 @@ BindsTo=neo4j-red@%i.service
 After=neo4j-red@%i.service
 
 [Service]
-ExecStart=/bin/sh -c "\
-  etcdctl set /vulcand/backends/neo4j-read/backend '{\"Type\": \"http\"}'; \
-  etcdctl set /vulcand/frontends/neo4j-read/frontend '{\"Type\": \"http\", \"BackendId\": \"neo4j-read\", \"Route\": \"PathRegexp(`/__neo4j-read/.*`)\"}'; \
-  etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite '{\"Id\":\"rewrite\", \"Type\":\"rewrite\", \"Priority\":1, \"Middleware\": {\"Regexp\":\"/__neo4j-read(/.*)\", \"Replacement\":\"$1\"}}'; \
+ExecStart=/bin/sh -c '\
+  etcdctl set /vulcand/backends/neo4j-read/backend \'{"Type": "http"}\'; \
+  etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
+  etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
+  etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
   while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port neo4j-red-%i 7474 | cut -d':' -f2)`; \
-    etcdctl set /vulcand/backends/neo4j-read/servers/1 \"{\\\"url\\\": \\\"http://$HOSTNAME:$PORT\\\"}\" --ttl 5; \
+    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port neo4j-red-%i 7474 | cut -d":" -f2)`; \
+    etcdctl set /vulcand/backends/neo4j-read/servers/1 "{\\"url\\": \\"http://$HOSTNAME:$PORT\\"}" --ttl 5; \
     sleep 4; \
-  done"
+  done'
 ExecStop=/usr/bin/etcdctl rm /vulcand/backends/neo4j-read/servers/1
 
 [X-Fleet]


### PR DESCRIPTION
This not ideal but it works. 
Neo4j/neo4j driver try to do all sorts of clever things and compute their own urls when they try to connect to neo using the Host header of the first response. This means that the 2nd request to neo4j will not go via vulcan. As a side-effect the app becomes unhealthy when the neo4j instance which the app initially connected to goes down. 
{ "TrustForwardHeader": true, "PassHostHeader": true } solves this problem and routes all the requests via vulcan.

The second problem, now that all requests go via vulcan is that the driver also overwrites the path it uses to connect: /__neo4j-read/db/data becomes /db/data. As a workaround neo4j-read-db was added.

As a conclusion neo4j and its driver don't play nice when you overwrite the Host header or rewriter the url path. We should consider updating the public read apis to set a header(not Host) to be used for routing. 