### PR TITLE
WP Image Mapper

### DIFF
--- a/content-ingester-neo4j-blue@.service
+++ b/content-ingester-neo4j-blue@.service
@@ -21,7 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
-  export WHITELIST="^http://(methode|wordpress)(-article|-image-model|-list)?-transformer-(pr|iw)-uk-.*\\.svc\\.ft\\.com(:\\d{2,5})?/(content|image/model|image-set/model|lists)/[\\w-]+.*$"; \
+  export WHITELIST="^http://(methode|wordpress)(-article|-image-model|-image)?(-transformer|-mapper)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content|image/model|image-set/model)/[\\w-]+.*$"; \
   export WRITER_HEALTHCHECK_NAME="Can connect to the Content RW Neo4j"; \
   export WRITER_HEALTHCHECK_TECH_SUMMARY="Tests that the build-info endpoint for the Content rw neo4j returns a 200 response"; \
   /usr/bin/docker run --rm --name %p-%i -p 8080 -p 8081 \

--- a/content-ingester-neo4j-red@.service
+++ b/content-ingester-neo4j-red@.service
@@ -21,7 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
-  export WHITELIST="^http://(methode|wordpress)(-article|-image-model|-list)?-transformer-(pr|iw)-uk-.*\\.svc\\.ft\\.com(:\\d{2,5})?/(content|image/model|image-set/model|lists)/[\\w-]+.*$"; \
+  export WHITELIST="^http://(methode|wordpress)(-article|-image-model|-image)?(-transformer|-mapper)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content|image/model|image-set/model)/[\\w-]+.*$"; \
   export WRITER_HEALTHCHECK_NAME="Can connect to the Content RW Neo4j"; \
   export WRITER_HEALTHCHECK_TECH_SUMMARY="Tests that the build-info endpoint for the Content rw neo4j returns a 200 response"; \
   /usr/bin/docker run --rm --name %p-%i -p 8080 -p 8081 \

--- a/content-ingester@.service
+++ b/content-ingester@.service
@@ -21,7 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
-  export WHITELIST="^http://(methode|wordpress)(-article|-image-model|-image)?(-transformer|-mapper)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content|image/model|image-set/model|lists)/[\\w-]+.*$"; \
+  export WHITELIST="^http://(methode|wordpress)(-article|-image-model|-list|-image)?(-transformer|-mapper)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content|image/model|image-set/model|lists)/[\\w-]+.*$"; \
   export WRITER_HEALTHCHECK_NAME="Can connect to the Document Store"; \
   export WRITER_HEALTHCHECK_TECH_SUMMARY="Tests that the build-info endpoint for the Document Store returns a 200 response"; \
   /usr/bin/docker run --rm --name %p-%i -p 8080 -p 8081 \

--- a/content-ingester@.service
+++ b/content-ingester@.service
@@ -21,7 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
-  export WHITELIST="^http://(methode|wordpress)(-article|-image-model|-list)?-transformer-(pr|iw)-uk-.*\\.svc\\.ft\\.com(:\\d{2,5})?/(content|image/model|image-set/model|lists)/[\\w-]+.*$"; \
+  export WHITELIST="^http://(methode|wordpress)(-article|-image-model|-image)?(-transformer|-mapper)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content|image/model|image-set/model|lists)/[\\w-]+.*$"; \
   export WRITER_HEALTHCHECK_NAME="Can connect to the Document Store"; \
   export WRITER_HEALTHCHECK_TECH_SUMMARY="Tests that the build-info endpoint for the Document Store returns a 200 response"; \
   /usr/bin/docker run --rm --name %p-%i -p 8080 -p 8081 \

--- a/services.yaml
+++ b/services.yaml
@@ -390,4 +390,9 @@ services:
 - name: wordpress-article-transformer@.service
   version: v46
   count: 2
+- name: wordpress-image-mapper-sidekick@.service
+  count: 2
+- name: wordpress-image-mapper@.service
+  version: v22
+  count: 2
 - name: zookeeper.service

--- a/services.yaml
+++ b/services.yaml
@@ -393,6 +393,6 @@ services:
 - name: wordpress-image-mapper-sidekick@.service
   count: 2
 - name: wordpress-image-mapper@.service
-  version: v22
+  version: v23
   count: 2
 - name: zookeeper.service

--- a/wordpress-image-mapper-sidekick@.service
+++ b/wordpress-image-mapper-sidekick@.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=wordpress image mapper sidekick
+BindsTo=wordpress-image-mapper@%i.service
+After=wordpress-image-mapper@%i.service
+
+[Service]
+ExecStart=/bin/sh -c "\
+  etcdctl set   /ft/services/wordpress-image-mapper/healthcheck     true; \
+    etcdctl mkdir /ft/services/wordpress-image-mapper/servers; \
+    etcdctl set /ft/healthcheck/wordpress-image-mapper-%i/path /__health; \
+  while true; do \
+      export PORT=$(/usr/bin/docker port wordpress-image-mapper-%i 8080 | cut -d':' -f2); \
+      etcdctl set /ft/services/wordpress-image-mapper/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
+      sleep 120; \
+    done"
+ExecStop=/usr/bin/etcdctl rm /ft/services/wordpress-image-mapper/servers/%i
+
+[X-Fleet]
+MachineOf=wordpress-image-mapper@%i.service

--- a/wordpress-image-mapper-sidekick@.service
+++ b/wordpress-image-mapper-sidekick@.service
@@ -5,12 +5,12 @@ After=wordpress-image-mapper@%i.service
 
 [Service]
 ExecStart=/bin/sh -c "\
-  etcdctl set   /ft/services/wordpress-image-mapper/healthcheck     true; \
+    etcdctl set   /ft/services/wordpress-image-mapper/healthcheck     true; \
     etcdctl mkdir /ft/services/wordpress-image-mapper/servers; \
     etcdctl set /ft/healthcheck/wordpress-image-mapper-%i/path /__health; \
   while true; do \
       export PORT=$(/usr/bin/docker port wordpress-image-mapper-%i 8080 | cut -d':' -f2); \
-      etcdctl set /ft/services/wordpress-image-mapper/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
+      etcdctl set /ft/services/wordpress-image-mapper/servers/%i \"http://$HOSTNAME:$PORT\" --ttl 600; \
       sleep 120; \
     done"
 ExecStop=/usr/bin/etcdctl rm /ft/services/wordpress-image-mapper/servers/%i

--- a/wordpress-image-mapper@.service
+++ b/wordpress-image-mapper@.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=wordpress image mapper
+After=docker.service
+Requires=docker.service
+Wants=wordpress-image-mapper-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove
+# work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker pull up-registry.ft.com/coco/wordpress-image-mapper:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/sh -c '\
+  /usr/bin/docker run --rm --name %p-%i -p 8080 -p 8081  --env "KAFKA_PROXY=$HOSTNAME:8080" up-registry.ft.com/coco/wordpress-image-mapper:$DOCKER_APP_VERSION'
+
+ExecStop=/usr/bin/docker stop -t 3 %p-%i
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=%p@*.service

--- a/wordpress-image-mapper@.service
+++ b/wordpress-image-mapper@.service
@@ -10,12 +10,12 @@ TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
-ExecStartPre=/bin/bash -c 'docker pull up-registry.ft.com/coco/wordpress-image-mapper:$DOCKER_APP_VERSION'
+ExecStartPre=-/bin/sh -c 'docker kill %p-%i >/dev/null 2>&1'
+ExecStartPre=-/bin/sh -c 'docker rm %p-%i >/dev/null 2>&1'
+ExecStartPre=/bin/sh -c 'docker history up-registry.ft.com/coco/wordpress-image-mapper:$DOCKER_APP_VERSION >/dev/null 2>&1 || docker pull up-registry.ft.com/coco/wordpress-image-mapper:$DOCKER_APP_VERSION'
 
 ExecStart=/bin/sh -c '\
-  /usr/bin/docker run --rm --name %p-%i -p 8080 -p 8081  --env "KAFKA_PROXY=$HOSTNAME:8080" up-registry.ft.com/coco/wordpress-image-mapper:$DOCKER_APP_VERSION'
+  /usr/bin/docker run --rm --name %p-%i -p 8080 -p 8081 -e "KAFKA_PROXY=$HOSTNAME:8080" up-registry.ft.com/coco/wordpress-image-mapper:$DOCKER_APP_VERSION'
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure


### PR DESCRIPTION
Introduces the new Wordpress Image Mapper service. It listens to the Native Topic on Kafka for Wordpress payloads and extracts the Featured Image. It creates two messages on CmsPublicationEvents for ImageSet and ImageModel. The ingester whitelists are updated to allow publishing of the ImageSet and ImageModel for contentUris matching the wordpress image mapper.