### PR TITLE
Bumped nativerw to v42 - unique index on uuids

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -167,7 +167,7 @@ services:
 - name: nativerw-sidekick@.service
   count: 2
 - name: nativerw@.service
-  version: v41
+  version: v42
   count: 2
   sequentialDeployment: true
 - name: neo4j-blue-sidekick@.service


### PR DESCRIPTION
https://github.com/Financial-Times/nativerw/pull/10
* tried this is in XP and it works IF the collections don't have duplicates AND the collections doesn't already have an index with this name
* rollout procedure:
 * release the app (shouldn't fail on startup)
 * delete all duplicates from all collections (find them with the command at the bottom of this PR)
 * delete all existing indexes
 * restart one nativerw node, this should apply the index
 * verify that the index is there

**Example of the index**
```
{
		"v" : 1,
		"unique" : true,
		"key" : {
			"uuid" : 1
		},
		"name" : "uuid_1",
		"ns" : "native-store.wordpress",
		"background" : true
	}
]
```

**How to check for duplicate ids**
`curl -s  localhost:8080/__nativerw/wordpress/__ids | sort | uniq -c | awk '{print $1,$2}' | grep -v ^1 | cut -d'"' -f4`
