### PR TITLE
Up ttl for load testing

### DIFF
--- a/api-policy-component-sidekick@.service
+++ b/api-policy-component-sidekick@.service
@@ -11,8 +11,8 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/healthcheck/api-policy-component-%i/categories read; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port api-policy-component-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/api-policy-component/servers/%i http://%H:$PORT --ttl 5; \
-    sleep 4; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/api-policy-component/servers/%i http://%H:$PORT --ttl 10; \
+    sleep 5; \
   done"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/api-policy-component/servers/%i

--- a/content-public-read-preview-sidekick@.service
+++ b/content-public-read-preview-sidekick@.service
@@ -12,8 +12,8 @@ ExecStart=/bin/sh -c '\
   etcdctl set 	/vulcand/frontends/public-services-preview/frontend 		\'{"Type": "http", "BackendId": "vcb-content-public-read-preview", "Route": "PathRegexp(`/content-preview/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}.*`) && Host(`public-services`)"}\'; \
   while true; do \
     export PORT=$(echo $(/usr/bin/docker port content-public-read-preview-%i 8080) | cut -d":" -f2); \
-    etcdctl set /ft/services/content-public-read-preview/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
-    sleep 120; \
+    etcdctl set /ft/services/content-public-read-preview/servers/%i "http://$HOSTNAME:$PORT" --ttl 10; \
+    sleep 5; \
   done'
 ExecStop=/usr/bin/etcdctl rm /ft/services/content-public-read-preview/servers/%i
 

--- a/document-store-api-sidekick@.service
+++ b/document-store-api-sidekick@.service
@@ -14,8 +14,8 @@ ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/frontends/public-services-lists/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/lists/.*`) && Host(`public-services`)\"}'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port document-store-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/document-store-api/servers/%i http://%H:$PORT --ttl 5; \
-    sleep 4; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/document-store-api/servers/%i http://%H:$PORT --ttl 10; \
+    sleep 5; \
   done"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/document-store-api/servers/%i

--- a/enriched-content-read-api-sidekick@.service
+++ b/enriched-content-read-api-sidekick@.service
@@ -12,8 +12,8 @@ ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/frontends/public-services-enrichedcontent/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-enriched-content-read-api\", \"Route\": \"PathRegexp(`/enrichedcontent/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`) && Host(`public-services`)\"}'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port enriched-content-read-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/enriched-content-read-api/servers/%i http://%H:$PORT --ttl 5; \
-    sleep 4; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/enriched-content-read-api/servers/%i http://%H:$PORT --ttl 10; \
+    sleep 5; \
   done"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/enriched-content-read-api/servers/%i

--- a/public-annotations-api-sidekick@.service
+++ b/public-annotations-api-sidekick@.service
@@ -10,8 +10,8 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/healthcheck/public-annotations-api-%i/path /__health; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-annotations-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-annotations-api/servers/%i http://%H:$PORT --ttl 5; \
-    sleep 4; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-annotations-api/servers/%i http://%H:$PORT --ttl 10; \
+    sleep 5; \
   done"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/public-annotations-api/servers/%i

--- a/public-content-by-concept-api-sidekick@.service
+++ b/public-content-by-concept-api-sidekick@.service
@@ -12,8 +12,8 @@ ExecStart=/bin/sh -c '\
   etcdctl set 	/vulcand/frontends/public-services-content-by-concept/frontend 	\'{"Type": "http", "BackendId": "vcb-public-content-by-concept-api", "Route": "PathRegexp(`^\/content.*isAnnotatedBy=.*$`) && Host(`public-services`)"}\'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-content-by-concept-api-%i 8080 | cut -d":" -f2)`; \
-    curl -s -H "Accept: application/json" 0.0.0.0:$PORT/__health | jq -e \'[.checks[].ok] | all\' 2>&1>/dev/null && etcdctl set /ft/services/public-content-by-concept-api/servers/%i http://%H:$PORT --ttl 5; \
-    sleep 4; \
+    curl -s -H "Accept: application/json" 0.0.0.0:$PORT/__health | jq -e \'[.checks[].ok] | all\' 2>&1>/dev/null && etcdctl set /ft/services/public-content-by-concept-api/servers/%i http://%H:$PORT --ttl 10; \
+    sleep 5; \
   done'
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/public-content-by-concept-api/servers/%i

--- a/public-organisations-api-sidekick@.service
+++ b/public-organisations-api-sidekick@.service
@@ -12,8 +12,8 @@ ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/frontends/public-services-organisations/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-public-organisations-api\", \"Route\": \"PathRegexp(`/organisations/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`) && Host(`public-services`)\"}'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-organisations-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-organisations-api/servers/%i http://%H:$PORT --ttl 5; \
-    sleep 4; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-organisations-api/servers/%i http://%H:$PORT --ttl 10; \
+    sleep 5; \
   done"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/public-organisations-api/servers/%i

--- a/public-people-api-sidekick@.service
+++ b/public-people-api-sidekick@.service
@@ -13,7 +13,7 @@ ExecStart=/bin/sh -c "\
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-people-api-%i 8080 | cut -d':' -f2)`; \
     curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-people-api/servers/%i http://%H:$PORT --ttl 10; \
-    sleep 4; \
+    sleep 5; \
   done"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/public-people-api/servers/%i

--- a/public-people-api-sidekick@.service
+++ b/public-people-api-sidekick@.service
@@ -12,7 +12,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/frontends/public-services-people/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-public-people-api\", \"Route\": \"PathRegexp(`/people/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`) && Host(`public-services`)\"}'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-people-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-people-api/servers/%i http://%H:$PORT --ttl 5; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-people-api/servers/%i http://%H:$PORT --ttl 10; \
     sleep 4; \
   done"
 

--- a/public-things-api-sidekick@.service
+++ b/public-things-api-sidekick@.service
@@ -12,8 +12,8 @@ ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/frontends/public-services-things/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-public-things-api\", \"Route\": \"PathRegexp(`/things/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`) && Host(`public-services`)\"}'; \
   while true; do \
     PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-things-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-things-api/servers/%i http://%H:$PORT --ttl 5; \
-    sleep 4; \
+    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-things-api/servers/%i http://%H:$PORT --ttl 10; \
+    sleep 5; \
   done"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/public-things-api/servers/%i


### PR DESCRIPTION
Occasionally etcd takes longer then 1 second to consolidate values across the cluster and the backends drop out from vulcan:

```
ge &engine.ServerDeleted{ServerKey:engine.ServerKey{BackendKey:engine.BackendKey{Id:"vcb-public-people-api-1"}, Id:"1"}}, err: vcb-public-people-api-1 not found
ge &engine.ServerDeleted{ServerKey:engine.ServerKey{BackendKey:engine.BackendKey{Id:"vcb-public-people-api-2"}, Id:"2"}}, err: vcb-public-people-api-2 not found
```

With no backends available, vulcan returns `500`.

This ups the TTL to 10 seconds, having enough overlap where services no longer get dropped by the load balancer.