### PR TITLE
Bump aggregate-healthcheck to 1.0.7 

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -2,7 +2,7 @@ services:
 - name: aggregate-healthcheck-sidekick@.service
   count: 1
 - name: aggregate-healthcheck@.service
-  version: v1.0.6
+  version: v1.0.7
   count: 1
 - name: api-policy-component-sidekick@.service
   count: 2


### PR DESCRIPTION
with fix for connection pileup andd rephrase of critical to warning for low severity apps.