### PR TITLE
Making sure vulcan backends to not expire for public-annotations-api

### DIFF
--- a/api-policy-component-sidekick@.service
+++ b/api-policy-component-sidekick@.service
@@ -4,16 +4,19 @@ BindsTo=api-policy-component@%i.service
 After=api-policy-component@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
-  etcdctl set /ft/services/api-policy-component/healthcheck true; \
-  etcdctl mkdir /ft/services/api-policy-component/servers; \
-  etcdctl set /ft/healthcheck/api-policy-component-%i/path /__health; \
-  etcdctl set /ft/healthcheck/api-policy-component-%i/categories read; \
-  while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port api-policy-component-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/api-policy-component/servers/%i http://%H:$PORT --ttl 10; \
+  export SERVICE=$(echo %p | sed "s/-sidekick//g"); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/categories read; \
+  while [ -z $PORT ]; do \
+    PORT=`echo $(/usr/bin/docker port $SERVICE-%i 8080 | cut -d':' -f2)`; \
+    echo 'Port not set, retrying'; \
     sleep 5; \
-  done"
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/api-policy-component/servers/%i
 

--- a/document-store-api-sidekick@.service
+++ b/document-store-api-sidekick@.service
@@ -4,19 +4,22 @@ BindsTo=document-store-api@%i.service
 After=document-store-api@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
-  etcdctl set   /ft/services/document-store-api/healthcheck     true; \
-  etcdctl mkdir /ft/services/document-store-api/servers; \
-  etcdctl set /ft/healthcheck/document-store-api-%i/path /__health; \
-  etcdctl set /ft/healthcheck/document-store-api-%i/categories read; \
+  export SERVICE=$(echo %p | sed "s/-sidekick//g"); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/categories read; \
   etcdctl set /vulcand/frontends/public-services-content/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`) && Host(`public-services`)\"}'; \
   etcdctl set /vulcand/frontends/public-services-content/middlewares/rewrite '{\"Id\":\"rewrite\", \"Type\":\"rewrite\", \"Priority\":1, \"Middleware\": {\"Regexp\":\"/content/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\", \"Replacement\":\"/content-read/$1\"}}'; \
   etcdctl set /vulcand/frontends/public-services-lists/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/lists/.*`) && Host(`public-services`)\"}'; \
-  while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port document-store-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/document-store-api/servers/%i http://%H:$PORT --ttl 10; \
+  while [ -z $PORT ]; do \
+    PORT=`echo $(/usr/bin/docker port $SERVICE-%i 8080 | cut -d':' -f2)`; \
+    echo 'Port not set, retrying'; \
     sleep 5; \
-  done"
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/document-store-api/servers/%i
 

--- a/enriched-content-read-api-sidekick@.service
+++ b/enriched-content-read-api-sidekick@.service
@@ -4,17 +4,20 @@ BindsTo=enriched-content-read-api@%i.service
 After=enriched-content-read-api@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
-  etcdctl set   /ft/services/enriched-content-read-api/healthcheck     true; \
-  etcdctl mkdir /ft/services/enriched-content-read-api/servers; \
-  etcdctl set /ft/healthcheck/enriched-content-read-api-%i/path /__health; \
-  etcdctl set /ft/healthcheck/enriched-content-read-api-%i/categories read; \
+  export SERVICE=$(echo %p | sed "s/-sidekick//g"); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/categories read; \
   etcdctl set /vulcand/frontends/public-services-enrichedcontent/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-enriched-content-read-api\", \"Route\": \"PathRegexp(`/enrichedcontent/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`) && Host(`public-services`)\"}'; \
-  while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port enriched-content-read-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/enriched-content-read-api/servers/%i http://%H:$PORT --ttl 10; \
+  while [ -z $PORT ]; do \
+    PORT=`echo $(/usr/bin/docker port $SERVICE-%i 8080 | cut -d':' -f2)`; \
+    echo 'Port not set, retrying'; \
     sleep 5; \
-  done"
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/enriched-content-read-api/servers/%i
 

--- a/neo4j-read-blue-sidekick@.service
+++ b/neo4j-read-blue-sidekick@.service
@@ -4,16 +4,18 @@ BindsTo=neo4j-blue@%i.service
 After=neo4j-blue@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c '\
    etcdctl set /vulcand/backends/neo4j-read/backend \'{"Type": "http"}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
    etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
-   while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port neo4j-blue-%i 7474 | cut -d":" -f2)`; \
-    etcdctl set /vulcand/backends/neo4j-read/servers/2 "{\\"url\\": \\"http://$HOSTNAME:$PORT\\"}" --ttl 5; \
-    sleep 4; \
-  done'
+   while [ -z $PORT ]; do \
+     PORT=`echo $(/usr/bin/docker port neo4j-blue-%i 7474 | cut -d":" -f2)`; \
+     echo "Port not set, retrying"; \
+     sleep 5; \
+   done; \
+   etcdctl set /vulcand/backends/neo4j-read/servers/2 "{\\"url\\": \\"http://$HOSTNAME:$PORT\\"}"'
 ExecStop=/usr/bin/etcdctl rm /vulcand/backends/neo4j-read/servers/2
 
 [X-Fleet]

--- a/neo4j-read-red-sidekick@.service
+++ b/neo4j-read-red-sidekick@.service
@@ -4,16 +4,18 @@ BindsTo=neo4j-red@%i.service
 After=neo4j-red@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c '\
   etcdctl set /vulcand/backends/neo4j-read/backend \'{"Type": "http"}\'; \
   etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
   etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
   etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
-  while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port neo4j-red-%i 7474 | cut -d":" -f2)`; \
-    etcdctl set /vulcand/backends/neo4j-read/servers/1 "{\\"url\\": \\"http://$HOSTNAME:$PORT\\"}" --ttl 5; \
-    sleep 4; \
-  done'
+  while [ -z $PORT ]; do \
+    PORT=`echo $(/usr/bin/docker port neo4j-red-%i 7474 | cut -d":" -f2)`; \
+    echo "Port not set, retrying"; \
+    sleep 5; \
+  done; \
+  etcdctl set /vulcand/backends/neo4j-read/servers/1 "{\\"url\\": \\"http://$HOSTNAME:$PORT\\"}"'
 ExecStop=/usr/bin/etcdctl rm /vulcand/backends/neo4j-read/servers/1
 
 [X-Fleet]

--- a/public-annotations-api-sidekick@.service
+++ b/public-annotations-api-sidekick@.service
@@ -17,6 +17,7 @@ ExecStart=/bin/sh -c "\
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
+ExecStop=/usr/bin/etcdctl rm /ft/services/public-annotations-api/servers/%i
 Restart=on-failure
 RestartSec=60
 

--- a/public-annotations-api-sidekick@.service
+++ b/public-annotations-api-sidekick@.service
@@ -6,15 +6,16 @@ After=public-annotations-api@%i.service
 [Service]
 RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
-  etcdctl set   /ft/services/public-annotations-api/healthcheck     true; \
-  etcdctl mkdir /ft/services/public-annotations-api/servers; \
-  etcdctl set /ft/healthcheck/public-annotations-api-%i/path /__health; \
+  export SERVICE=$(echo %p | sed "s/-sidekick//g"); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
   while [ -z $PORT ]; do \
-    PORT=`echo $(/usr/bin/docker port public-annotations-api-%i 8080 | cut -d':' -f2)`; \
+    PORT=`echo $(/usr/bin/docker port $SERVICE-%i 8080 | cut -d':' -f2)`; \
     echo 'Port not set, retrying'; \
     sleep 5; \
   done; \
-  etcdctl set /ft/services/public-annotations-api/servers/%i http://%H:$PORT;"
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
 Restart=on-failure
 RestartSec=60

--- a/public-annotations-api-sidekick@.service
+++ b/public-annotations-api-sidekick@.service
@@ -4,17 +4,18 @@ BindsTo=public-annotations-api@%i.service
 After=public-annotations-api@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
   etcdctl set   /ft/services/public-annotations-api/healthcheck     true; \
   etcdctl mkdir /ft/services/public-annotations-api/servers; \
   etcdctl set /ft/healthcheck/public-annotations-api-%i/path /__health; \
-  while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-annotations-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-annotations-api/servers/%i http://%H:$PORT --ttl 10; \
+  while [ -z $PORT ]; do \
+    PORT=`echo $(/usr/bin/docker port public-annotations-api-%i 8080 | cut -d':' -f2)`; \
+    echo 'Port not set, retrying'; \
     sleep 5; \
-  done"
+  done; \
+  etcdctl set /ft/services/public-annotations-api/servers/%i http://%H:$PORT;"
 
-ExecStop=/usr/bin/etcdctl rm /ft/services/public-annotations-api/servers/%i
 Restart=on-failure
 RestartSec=60
 

--- a/public-things-api-sidekick@.service
+++ b/public-things-api-sidekick@.service
@@ -4,17 +4,20 @@ BindsTo=public-things-api@%i.service
 After=public-things-api@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
-  etcdctl set   /ft/services/public-things-api/healthcheck     true; \
-  etcdctl mkdir /ft/services/public-things-api/servers; \
-  etcdctl set /ft/healthcheck/public-things-api-%i/path /__health; \
-  etcdctl set /ft/healthcheck/public-things-api-%i/categories read; \
+  export SERVICE=$(echo %p | sed "s/-sidekick//g"); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/categories read; \
   etcdctl set /vulcand/frontends/public-services-things/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-public-things-api\", \"Route\": \"PathRegexp(`/things/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`) && Host(`public-services`)\"}'; \
-  while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port public-things-api-%i 8080 | cut -d':' -f2)`; \
-    curl -s -H \"Accept: application/json\" 0.0.0.0:$PORT/__health | jq -e '[.checks[].ok] | all' 2>&1>/dev/null && etcdctl set /ft/services/public-things-api/servers/%i http://%H:$PORT --ttl 10; \
+  while [ -z $PORT ]; do \
+    PORT=`echo $(/usr/bin/docker port $SERVICE-%i 8080 | cut -d':' -f2)`; \
+    echo 'Port not set, retrying'; \
     sleep 5; \
-  done"
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
 ExecStop=/usr/bin/etcdctl rm /ft/services/public-things-api/servers/%i
 Restart=on-failure


### PR DESCRIPTION
We can't get rid of sidekicks yet because of the deployer. @tamas-molnar is updating deployer to be able to cope with missing sidekicks for sequential deployment.

Any thoughts before I implement the same chaneg for the rest of our read apis?