### PR TITLE
Switch to forked versions of zookeeper and kafka

### DIFF
--- a/kafka.service
+++ b/kafka.service
@@ -8,11 +8,11 @@ TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p > /dev/null 2>&1'
-ExecStartPre=/usr/bin/docker pull wurstmeister/kafka:0.8.2.0
-ExecStart=/bin/bash -c "\
-  /usr/bin/docker run --rm --name %p -p 9092:9092 --link zookeeper:zk --env \"KAFKA_ADVERTISED_HOST_NAME=$$HOSTNAME\" --env=\"KAFKA_MESSAGE_MAX_BYTES=16777216\" --env=\"KAFKA_REPLICA_FETCH_MAX_BYTES=16777216\" -v /vol/kafka:/kafka -v /var/run/docker.sock:/var/run/docker.sock wurstmeister/kafka:0.8.2.0"
+ExecStartPre=-/bin/sh -c '/usr/bin/docker kill %p >/dev/null 2>&1'
+ExecStartPre=-/bin/sh -c '/usr/bin/docker rm %p >/dev/null 2>&1'
+ExecStartPre=/bin/sh -c 'docker history coco/kafka-docker:0.9.0.1 >/dev/null 2>&1 || docker pull coco/kafka-docker:0.9.0.1'
+ExecStart=/bin/sh -c '\
+  docker run --rm --name %p -p 9092:9092 --link zookeeper:zk -e "KAFKA_ADVERTISED_HOST_NAME=$$HOSTNAME" -e="KAFKA_MESSAGE_MAX_BYTES=16777216" -e="KAFKA_REPLICA_FETCH_MAX_BYTES=16777216" -v /vol/kafka:/kafka -v /var/run/docker.sock:/var/run/docker.sock coco/kafka-docker:0.9.0.1'
 ExecStop=/usr/bin/docker stop %p
 ExecStartPost=/bin/sh -c "\
   KAFKA_IP=$HOSTNAME; \

--- a/kafka.service
+++ b/kafka.service
@@ -12,7 +12,7 @@ ExecStartPre=-/bin/sh -c '/usr/bin/docker kill %p >/dev/null 2>&1'
 ExecStartPre=-/bin/sh -c '/usr/bin/docker rm %p >/dev/null 2>&1'
 ExecStartPre=/bin/sh -c 'docker history coco/kafka-docker:0.9.0.1 >/dev/null 2>&1 || docker pull coco/kafka-docker:0.9.0.1'
 ExecStart=/bin/sh -c '\
-  docker run --rm --name %p -p 9092:9092 --link zookeeper:zk -e "KAFKA_ADVERTISED_HOST_NAME=$$HOSTNAME" -e="KAFKA_MESSAGE_MAX_BYTES=16777216" -e="KAFKA_REPLICA_FETCH_MAX_BYTES=16777216" -v /vol/kafka:/kafka -v /var/run/docker.sock:/var/run/docker.sock coco/kafka-docker:0.9.0.1'
+  docker run --rm --name %p -p 9092:9092 --link zookeeper:zk -e="KAFKA_ADVERTISED_HOST_NAME=$$HOSTNAME" -e="KAFKA_MESSAGE_MAX_BYTES=16777216" -e="KAFKA_REPLICA_FETCH_MAX_BYTES=16777216" -v /vol/kafka:/kafka -v /var/run/docker.sock:/var/run/docker.sock coco/kafka-docker:0.9.0.1'
 ExecStop=/usr/bin/docker stop %p
 ExecStartPost=/bin/sh -c "\
   KAFKA_IP=$HOSTNAME; \

--- a/zookeeper.service
+++ b/zookeeper.service
@@ -9,10 +9,10 @@ TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p > /dev/null 2>&1'
-ExecStartPre=/usr/bin/docker pull wurstmeister/zookeeper
-ExecStart=/usr/bin/docker run --name %p -v /vol/zk:/opt/zookeeper-3.4.6/data -p 2181:2181 wurstmeister/zookeeper
+ExecStartPre=-/bin/sh -c 'docker kill %p >/dev/null 2>&1'
+ExecStartPre=-/bin/sh -c 'docker rm %p >/dev/null 2>&1'
+ExecStartPre=/bin/sh -c 'docker history coco/zookeeper-docker:3.4.6-30d7482 >/dev/null 2>&1 || docker pull coco/zookeeper-docker:3.4.6-30d7482'
+ExecStart=/usr/bin/docker run --name %p -v /vol/zk:/opt/zookeeper-3.4.6/data -p 2181:2181 coco/zookeeper-docker:3.4.6-30d7482
 ExecStartPost=/bin/sh -c "\
   etcdctl set /ft/config/zookeeper/ip $HOSTNAME; \
   etcdctl set /ft/config/zookeeper/port 2181;"


### PR DESCRIPTION
 - New version of kafka (0.9.0.1) direct fork of
   wurstmeister/kafka-docker

 - Same version of zookeeper as current prod (3.4.6) with additional
   Dockerfile changes to reduce layers/image size

https://github.com/Financial-Times/kafka-docker
https://github.com/Financial-Times/zookeeper-docker