### PR TITLE
pam: skip notification check 4 deletes if there is no previous notification for that content

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -296,7 +296,7 @@ services:
 - name: publish-availability-monitor-sidekick@.service
   count: 1
 - name: publish-availability-monitor@.service
-  version: v0.17.0
+  version: v0.17.2
   count: 1
 - name: restorage-mongo-sidekick@.service
   count: 1


### PR DESCRIPTION
Includes @JuliaFernee's changes as well (0.17.1).
Both have been tested in lower environments (xp, dynpub).

Will be in pre-prod for the weekend.