### PR TITLE
Bump version of ingesters.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -44,17 +44,17 @@ services:
 - name: content-ingester-neo4j-blue-sidekick@.service
   count: 1
 - name: content-ingester-neo4j-blue@.service
-  version: v39
+  version: v44
   count: 1
 - name: content-ingester-neo4j-red-sidekick@.service
   count: 1
 - name: content-ingester-neo4j-red@.service
-  version: v39
+  version: v44
   count: 1
 - name: content-ingester-sidekick@.service
   count: 2
 - name: content-ingester@.service
-  version: v39
+  version: v44
   count: 2
 - name: content-preview-sidekick@.service
   count: 2
@@ -218,7 +218,7 @@ services:
 - name: notifications-ingester-sidekick@.service
   count: 2
 - name: notifications-ingester@.service
-  version: v39
+  version: v44
   count: 2
 - name: notifications-push-sidekick@.service
   count: 2


### PR DESCRIPTION
Looking at the commit history, the intermediate builds relate to Puppet
changes affecting UCS only.