### PR TITLE
WPAT convert links to ft content links

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -445,7 +445,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v85
+  version: v86
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -445,7 +445,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v81
+  version: v82
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -445,7 +445,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v80
+  version: v81
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -445,7 +445,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v82
+  version: v83
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -445,7 +445,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v83
+  version: v84
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -445,7 +445,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v84
+  version: v85
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -445,7 +445,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v76
+  version: v78
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -445,7 +445,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v78
+  version: v80
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
This version of WPAT has got changes ;
 - the conversion of the short links to FT content links.
- conversion of the <a> href.... </a> for blogs into FT content links.
- allowing of the blog posts without authors to get published in UPP.
- checks the links in the posts to find the content type in document store
