### PR TITLE
Feature/notificationrw create indices

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -229,7 +229,7 @@ services:
 - name: notifications-rw-sidekick@.service
   count: 2
 - name: notifications-rw@.service
-  version: v32
+  version: v35
   count: 2
 - name: organisations-rw-neo4j-blue-sidekick@.service
   count: 2


### PR DESCRIPTION
Notification RW service will now ensure the mongo notification collection indexes are created during its startup routine. If the indexes already exist, this should have no impact.