### PR TITLE
Bump content-importer and WPIM versions.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -165,7 +165,7 @@ services:
 - name: methode-content-importer-sidekick@.service
   count: 2
 - name: methode-content-importer@.service
-  version: v46
+  version: v49
   count: 2
 - name: methode-image-binary-transformer-sidekick@.service
   count: 2
@@ -450,6 +450,6 @@ services:
 - name: wordpress-image-mapper-sidekick@.service
   count: 2
 - name: wordpress-image-mapper@.service
-  version: v25
+  version: v27
   count: 2
 - name: zookeeper.service


### PR DESCRIPTION
These are the two services that produce messages for the
CmsPublicationEvents topic. (There is no requirement to deploy them
together, but it is convenient).