### PR TITLE
PAM: External content validation + running CMD in one process only

### DIFF
--- a/publish-availability-monitor@.service
+++ b/publish-availability-monitor@.service
@@ -24,7 +24,7 @@ ExecStart=/bin/bash -c '\
 	--env "CONTENT_URL=http://%H:8080/__document-store-api/content-read/" \
 	--env "LISTS_URL=http://%H:8080/__document-store-api/lists/" \
 	--env "NOTIFICATIONS_URL=http://%H:8080/__notifications-rw/content/notifications" \
-	--env "METHODE_ARTICLE_TRANSFORMER_URL=http://%H:8080/__methode-article-transformer/content-transform/" \
+	--env "METHODE_ARTICLE_TRANSFORMER_URL=http://%H:8080/__methode-article-transformer/content-transform" \
 	coco/publish-availability-monitor:$DOCKER_APP_VERSION'
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i

--- a/publish-availability-monitor@.service
+++ b/publish-availability-monitor@.service
@@ -24,7 +24,7 @@ ExecStart=/bin/bash -c '\
 	--env "CONTENT_URL=http://%H:8080/__document-store-api/content-read/" \
 	--env "LISTS_URL=http://%H:8080/__document-store-api/lists/" \
 	--env "NOTIFICATIONS_URL=http://%H:8080/__notifications-rw/content/notifications" \
-	--env "METHODE_ARTICLE_TRANSFORMER_URL=http://%H:8080/__methode-article-transformer/content-transformer/" \
+	--env "METHODE_ARTICLE_TRANSFORMER_URL=http://%H:8080/__methode-article-transformer/content-transform/" \
 	coco/publish-availability-monitor:$DOCKER_APP_VERSION'
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i

--- a/publish-availability-monitor@.service
+++ b/publish-availability-monitor@.service
@@ -24,6 +24,7 @@ ExecStart=/bin/bash -c '\
 	--env "CONTENT_URL=http://%H:8080/__document-store-api/content-read/" \
 	--env "LISTS_URL=http://%H:8080/__document-store-api/lists/" \
 	--env "NOTIFICATIONS_URL=http://%H:8080/__notifications-rw/content/notifications" \
+	--env "METHODE_ARTICLE_TRANSFORMER_URL=http://%H:8080/__methode-article-transformer/content-transformer/" \
 	coco/publish-availability-monitor:$DOCKER_APP_VERSION'
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i

--- a/services.yaml
+++ b/services.yaml
@@ -290,7 +290,7 @@ services:
 - name: publish-availability-monitor-sidekick@.service
   count: 1
 - name: publish-availability-monitor@.service
-  version: v0.18.1
+  version: v0.18.2
   count: 1
 - name: restorage-mongo-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -290,7 +290,7 @@ services:
 - name: publish-availability-monitor-sidekick@.service
   count: 1
 - name: publish-availability-monitor@.service
-  version: v0.17.2
+  version: v0.18.0
   count: 1
 - name: restorage-mongo-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -290,7 +290,7 @@ services:
 - name: publish-availability-monitor-sidekick@.service
   count: 1
 - name: publish-availability-monitor@.service
-  version: v0.18.0
+  version: v0.18.1
   count: 1
 - name: restorage-mongo-sidekick@.service
   count: 1


### PR DESCRIPTION
0.17.3-4 puppet-stuff
0.17.5 https://github.com/Financial-Times/publish-availability-monitor/pull/71
0.18.0 https://github.com/Financial-Times/publish-availability-monitor/pull/70
0.18.1 https://github.com/Financial-Times/publish-availability-monitor/pull/72
0.18.2 https://github.com/Financial-Times/publish-availability-monitor/commit/b1f82caf5be186cf0c6702acba9c5193a70316b8

Tested in xp & pre-prod