### PR TITLE
Added bridges for UCS Test. These should be deployed in lower envs only.

### DIFF
--- a/cms-kafka-bridge-ucs-test-sidekick@.service
+++ b/cms-kafka-bridge-ucs-test-sidekick@.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=CMS Kafka Bridge Prod Sidekick
-BindsTo=cms-kafka-bridge-prod@%i.service
-After=cms-kafka-bridge-prod@%i.service
+Description=CMS Kafka Bridge UCS Test Sidekick
+BindsTo=cms-kafka-bridge-ucs-test@%i.service
+After=cms-kafka-bridge-ucs-test@%i.service
 
 [Service]
 RemainAfterExit=yes
@@ -16,11 +16,11 @@ ExecStart=/bin/sh -c "\
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
-ExecStop=/usr/bin/etcdctl rm /ft/services/cms-kafka-bridge-prod/servers/%i
+ExecStop=/usr/bin/etcdctl rm /ft/services/cms-kafka-bridge-ucs-test/servers/%i
 Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-MachineOf=cms-kafka-bridge-prod@%i.service
+MachineOf=cms-kafka-bridge-ucs-test@%i.service
 
 

--- a/cms-kafka-bridge-ucs-test@.service
+++ b/cms-kafka-bridge-ucs-test@.service
@@ -2,7 +2,7 @@
 Description=CMS Kafka Bridge Prod
 After=vulcan.service
 Requires=docker.service
-Wants=cms-kafka-bridge-prod-sidekick@%i.service
+Wants=cms-kafka-bridge-ucs-test-sidekick@%i.service
 
 [Service]
 Environment="DOCKER_APP_VERSION=latest"
@@ -15,7 +15,7 @@ ExecStartPre=/bin/bash -c 'docker pull coco/coco-kafka-bridge:$DOCKER_APP_VERSIO
 
 ExecStart=/bin/sh -c '\
   export APP_PORT=8080; \
-  export QUEUE_PROXY_ADDRS=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com; \
+  export QUEUE_PROXY_ADDRS=https://kafka-proxy-pr-uk-t-2.glb.ft.com,https://kafka-proxy-pr-uk-t-2.glb.ft.com; \
   export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-kafka-bridge-prod"; \
   export AUTHORIZATION_KEY=$(/usr/bin/etcdctl get /ft/_credentials/kafka-bridge/authorization_key); \
   export VULCAN_AUTH=$(/usr/bin/etcdctl get /ft/_credentials/vulcand/authorization_header); \
@@ -25,4 +25,4 @@ Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-Conflicts=cms-kafka-bridge-prod@*.service
+Conflicts=cms-kafka-bridge-ucs-test@*.service

--- a/cms-metadata-kafka-bridge-ucs-test-sidekick@.service
+++ b/cms-metadata-kafka-bridge-ucs-test-sidekick@.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=CMS Metadata Kafka Bridge Prod Sidekick
-BindsTo=cms-metadata-kafka-bridge-prod@%i.service
-After=cms-metadata-kafka-bridge-prod@%i.service
+Description=CMS Metadata Kafka Bridge UCS Test Sidekick
+BindsTo=cms-metadata-kafka-bridge-ucs-test@%i.service
+After=cms-metadata-kafka-bridge-ucs-test@%i.service
 
 [Service]
 RemainAfterExit=yes
@@ -16,10 +16,10 @@ ExecStart=/bin/sh -c "\
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
-ExecStop=/usr/bin/etcdctl rm /ft/services/cms-metadata-kafka-bridge-prod/servers/%i
+ExecStop=/usr/bin/etcdctl rm /ft/services/cms-metadata-kafka-bridge-ucs-test/servers/%i
 Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-MachineOf=cms-metadata-kafka-bridge-prod@%i.service
+MachineOf=cms-metadata-kafka-bridge-ucs-test@%i.service
 

--- a/cms-metadata-kafka-bridge-ucs-test@.service
+++ b/cms-metadata-kafka-bridge-ucs-test@.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=CMS Metadata Kafka Bridge Prod
+Description=CMS Metadata Kafka Bridge UCS Test
 After=vulcan.service
 Requires=docker.service
-Wants=cms-metadata-kafka-bridge-prod-sidekick@%i.service
+Wants=cms-metadata-kafka-bridge-ucs-test-sidekick@%i.service
 
 [Service]
 Environment="DOCKER_APP_VERSION=latest"
@@ -15,7 +15,7 @@ ExecStartPre=/bin/bash -c 'docker pull coco/coco-kafka-bridge:$DOCKER_APP_VERSIO
 
 ExecStart=/bin/sh -c '\
   export APP_PORT=8080; \
-  export QUEUE_PROXY_ADDRS=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com; \
+  export QUEUE_PROXY_ADDRS=https://kafka-proxy-pr-uk-t-2.glb.ft.com,https://kafka-proxy-pr-uk-t-2.glb.ft.com; \
   export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-cms-metadata-kafka-bridge-prod"; \
   export AUTHORIZATION_KEY=$(/usr/bin/etcdctl get /ft/_credentials/kafka-bridge/authorization_key); \
   export VULCAN_AUTH=$(/usr/bin/etcdctl get /ft/_credentials/vulcand/authorization_header); \
@@ -25,4 +25,4 @@ Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-Conflicts=cms-metadata-kafka-bridge-prod@*.service
+Conflicts=cms-metadata-kafka-bridge-ucs-test@*.service

--- a/concept-suggestions-kafka-bridge-ucs-test-sidekick@.service
+++ b/concept-suggestions-kafka-bridge-ucs-test-sidekick@.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=Concept Suggestions Kafka Bridge Prod Sidekick
-BindsTo=concept-suggestions-kafka-bridge-prod@%i.service
-After=concept-suggestions-kafka-bridge-prod@%i.service
+Description=Concept Suggestions Kafka Bridge UCS Test Sidekick
+BindsTo=concept-suggestions-kafka-bridge-ucs-test@%i.service
+After=concept-suggestions-kafka-bridge-ucs-test@%i.service
 
 [Service]
 RemainAfterExit=yes
@@ -16,10 +16,10 @@ ExecStart=/bin/sh -c "\
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
-ExecStop=/usr/bin/etcdctl rm /ft/services/concept-suggestions-kafka-bridge-prod/servers/%i
+ExecStop=/usr/bin/etcdctl rm /ft/services/concept-suggestions-kafka-bridge-ucs-test/servers/%i
 Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-MachineOf=concept-suggestions-kafka-bridge-prod@%i.service
+MachineOf=concept-suggestions-kafka-bridge-ucs-test@%i.service
 

--- a/concept-suggestions-kafka-bridge-ucs-test@.service
+++ b/concept-suggestions-kafka-bridge-ucs-test@.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=Concept Suggestions Kafka Bridge Prod
+Description=Concept Suggestions Kafka Bridge UCS Test
 After=vulcan.service
 Requires=docker.service
-Wants=concept-suggestions-kafka-bridge-prod-sidekick@%i.service
+Wants=concept-suggestions-kafka-bridge-ucs-test-sidekick@%i.service
 
 [Service]
 Environment="DOCKER_APP_VERSION=latest"
@@ -15,7 +15,7 @@ ExecStartPre=/bin/bash -c 'docker pull coco/coco-kafka-bridge:$DOCKER_APP_VERSIO
 
 ExecStart=/bin/sh -c '\
   export APP_PORT=8080; \
-  export QUEUE_PROXY_ADDRS=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com; \
+  export QUEUE_PROXY_ADDRS=https://kafka-proxy-pr-uk-t-2.glb.ft.com,https://kafka-proxy-pr-uk-t-2.glb.ft.com; \
   export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-concept-suggestions-kafka-bridge-prod"; \
   export AUTHORIZATION_KEY=$(/usr/bin/etcdctl get /ft/_credentials/kafka-bridge/authorization_key); \
   export VULCAN_AUTH=$(/usr/bin/etcdctl get /ft/_credentials/vulcand/authorization_header); \
@@ -25,4 +25,4 @@ Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-Conflicts=concept-suggestions-kafka-bridge-prod@*.service
+Conflicts=concept-suggestions-kafka-bridge-ucs-test@*.service

--- a/services.yaml
+++ b/services.yaml
@@ -23,22 +23,22 @@ services:
   sequentialDeployment: true
 - name: cms-kafka-bridge-sidekick@.service
   count: 2
-- name: cms-kafka-bridge@.service
+- name: cms-kafka-bridge-ucs-test-sidekick@.service
+  count: 2
+- name: cms-kafka-bridge-ucs-test@.service
   version: v11.0.6
   count: 2
-- name: cms-kafka-bridge-prod-sidekick@.service
-  count: 2
-- name: cms-kafka-bridge-prod@.service
+- name: cms-kafka-bridge@.service
   version: v11.0.6
   count: 2
 - name: cms-metadata-kafka-bridge-sidekick@.service
   count: 2
-- name: cms-metadata-kafka-bridge@.service
+- name: cms-metadata-kafka-bridge-ucs-test-sidekick@.service
+  count: 2
+- name: cms-metadata-kafka-bridge-ucs-test@.service
   version: v11.0.6
   count: 2
-- name: cms-metadata-kafka-bridge-prod-sidekick@.service
-  count: 2
-- name: cms-metadata-kafka-bridge-prod@.service
+- name: cms-metadata-kafka-bridge@.service
   version: v11.0.6
   count: 2
 - name: cms-notifier-sidekick@.service
@@ -48,12 +48,12 @@ services:
   count: 1
 - name: concept-suggestions-kafka-bridge-sidekick@.service
   count: 2
-- name: concept-suggestions-kafka-bridge@.service
+- name: concept-suggestions-kafka-bridge-ucs-test-sidekick@.service
+  count: 2
+- name: concept-suggestions-kafka-bridge-ucs-test@.service
   version: v11.0.6
   count: 2
-- name: concept-suggestions-kafka-bridge-prod-sidekick@.service
-  count: 2
-- name: concept-suggestions-kafka-bridge-prod@.service
+- name: concept-suggestions-kafka-bridge@.service
   version: v11.0.6
   count: 2
 - name: content-ingester-neo4j-blue-sidekick@.service
@@ -434,7 +434,7 @@ services:
   count: 1
 - name: v1-orgs-transformer@.service
   version: v0.0.2
-  count: 1  
+  count: 1
 - name: v1-suggestor-sidekick@.service
   count: 2
 - name: v1-suggestor@.service


### PR DESCRIPTION
With this change lower env clusters will automatically consume traffic from both UCS Test and Prod without any manual changes.
@yolandeleungFT @nwrigh please cherry-pick this onto team branches
@nwrigh @scott-ace-newton  You might want to follow the same pattern for the bridges you guys are about to add