### PR TITLE
remove image-cleaner

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -116,8 +116,6 @@ services:
 - name: genres-rw-neo4j-red@.service
   version: v1.0.0
   count: 1
-- name: image-cleaner.service
-  version: 1.0.0
 - name: industry-classifications-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: industry-classifications-rw-neo4j-blue@.service


### PR DESCRIPTION
If `image-cleaner` is not the cause of https://github.com/coreos/bugs/issues/1204 it looks like its at least a huge catalyst.

By no means scientific, creating a new cluster against current stable AMI - results in 5 services per box being hit by the bug. Without `image-cleaner`, there was only the one service, and that annoyingly resolved itself over lunch.

Pushing this change to `dynpub-uk` also seems to have allowed most services to start up eventually.

This obviously creates the problem of disk space, but at least that one is understood and predictable. At the same time we just merged a PR https://github.com/Financial-Times/coco-provisioner/pull/108 that increases root volume size to 100G.

Do people feel like we need to do more testing to ascertain validity of this solution? At the very least we are going to leave this change in `pre-prod` and `dynpub-uk` over the weekend. 