### PR TITLE
Fixed sidekick@.service in order to accept query pararameters to lists endpoint

### DIFF
--- a/document-store-api-sidekick@.service
+++ b/document-store-api-sidekick@.service
@@ -13,7 +13,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/healthcheck/$SERVICE-%i/categories read; \
   etcdctl set /vulcand/frontends/public-services-content/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`) && Host(`public-services`)\"}'; \
   etcdctl set /vulcand/frontends/public-services-content/middlewares/rewrite '{\"Id\":\"rewrite\", \"Type\":\"rewrite\", \"Priority\":1, \"Middleware\": {\"Regexp\":\"/content/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\", \"Replacement\":\"/content-read/$1\"}}'; \
-  etcdctl set /vulcand/frontends/public-services-lists/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/lists/.*`) && Host(`public-services`)\"}'; \
+  etcdctl set /vulcand/frontends/public-services-lists/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/lists.*`) && Host(`public-services`)\"}'; \
   while [ -z $PORT ]; do \
     PORT=`echo $(/usr/bin/docker port $SERVICE-%i 8080 | cut -d':' -f2)`; \
     echo 'Port not set, retrying'; \


### PR DESCRIPTION
This fix will allow calls to the lists endpoint with query parameters without '/', such as `https://prod-uk-up.ft.com/lists?curatedTopStoriesFor=704a3225-9b5c-3b4f-93c7-8e6a6993bfb0`