### PR TITLE
Update genres-rw to v1.1.0

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -124,12 +124,12 @@ services:
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-blue@.service
-  version: fix-deletion
+  version: v1.1.3
   count: 1
 - name: genres-rw-neo4j-red-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-red@.service
-  version: fix-deletion
+  version: v1.1.3
   count: 1
 - name: image-cleaner.service
   version: 1.0.0

--- a/services.yaml
+++ b/services.yaml
@@ -124,12 +124,12 @@ services:
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-blue@.service
-  version: v1.1.2
+  version: fix-deletion
   count: 1
 - name: genres-rw-neo4j-red-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-red@.service
-  version: v1.1.2
+  version: fix-deletion
   count: 1
 - name: image-cleaner.service
   version: 1.0.0

--- a/services.yaml
+++ b/services.yaml
@@ -124,12 +124,12 @@ services:
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-blue@.service
-  version: v1.1.0
+  version: v1.1.1
   count: 1
 - name: genres-rw-neo4j-red-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-red@.service
-  version: v1.1.0
+  version: v1.1.1
   count: 1
 - name: image-cleaner.service
   version: 1.0.0

--- a/services.yaml
+++ b/services.yaml
@@ -124,12 +124,12 @@ services:
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-blue@.service
-  version: v1.0.0
+  version: v1.1.0
   count: 1
 - name: genres-rw-neo4j-red-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-red@.service
-  version: v1.0.0
+  version: v1.1.0
   count: 1
 - name: image-cleaner.service
   version: 1.0.0

--- a/services.yaml
+++ b/services.yaml
@@ -124,12 +124,12 @@ services:
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-blue@.service
-  version: v1.1.1
+  version: v1.1.2
   count: 1
 - name: genres-rw-neo4j-red-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-red@.service
-  version: v1.1.1
+  version: v1.1.2
   count: 1
 - name: image-cleaner.service
   version: 1.0.0


### PR DESCRIPTION
Changes include for the genres-rw-neo4j:

* Make all the alternative ids Identifier nodes
* Only use prefLabel
* Add build-info
* Update the RW for the new json model - coming out from the transformer