### PR TITLE
New varnish and splunk forwarder

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -464,7 +464,7 @@ services:
 - name: varnish-sidekick@.service
   count: 2
 - name: varnish@.service
-  version: v69
+  version: v70
   count: 2
   sequentialDeployment: true
 - name: video-mapper-sidekick@.service

--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -3,7 +3,7 @@ Description=Splunk forwarder
 
 [Service]
 Environment="DOCKER_SPLUNK_HTTP_FWD_VERSION=latest"
-Environment="DOCKER_LOGFILTER_VERSION=1.0.1"
+Environment="DOCKER_LOGFILTER_VERSION=1.0.2"
 TimeoutStartSec=1200
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.

--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -2,21 +2,23 @@
 Description=Splunk forwarder
 
 [Service]
+Environment="DOCKER_SPLUNK_HTTP_FWD_VERSION=latest"
+Environment="DOCKER_LOGFILTER_VERSION=1.0.1"
 TimeoutStartSec=1200
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-filter > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-http > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-filter > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-http > /dev/null 2>&1'
-ExecStartPre=/usr/bin/docker pull coco/coco-splunk-http-forwarder
-ExecStartPre=/usr/bin/docker pull coco/coco-logfilter
-ExecStart=/bin/bash -c "\
+ExecStartPre=-/bin/sh -c 'docker kill %p-filter > /dev/null 2>&1'
+ExecStartPre=-/bin/sh -c 'docker kill %p-http > /dev/null 2>&1'
+ExecStartPre=-/bin/sh -c 'docker rm %p-filter > /dev/null 2>&1'
+ExecStartPre=-/bin/sh -c 'docker rm %p-http > /dev/null 2>&1'
+ExecStartPre=/bin/sh -c 'docker history coco/coco-splunk-http-forwarder:$DOCKER_SPLUNK_HTTP_FWD_VERSION >/dev/null 2>&1 || docker pull coco/coco-splunk-http-forwarder:$DOCKER_SPLUNK_HTTP_FWD_VERSION'
+ExecStartPre=/bin/sh -c 'docker history coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION >/dev/null 2>&1 || docker pull coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION'
+ExecStart=/bin/sh -c '\
   export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_url); \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
-  /usr/bin/journalctl -a -f --since=now --output=json | docker run -i --log-driver=none --env=ENV=$ENV --rm --name %p-filter coco/coco-logfilter | docker run -i --log-driver=none --rm --name %p-http --env=\"FORWARD_URL=$FORWARD_URL\" coco/coco-splunk-http-forwarder"
-ExecStop=/bin/bash -c "/usr/bin/docker stop -t 3 %p-filter && /usr/bin/docker stop -t 3 %p-http"
+  journalctl -a -f --since=now --output=json | docker run -i --log-driver=none -e=ENV=$ENV --rm --name %p-filter coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION | docker run -i --log-driver=none --rm --name %p-http -e="FORWARD_URL=$FORWARD_URL" coco/coco-splunk-http-forwarder:$DOCKER_SPLUNK_HTTP_FWD_VERSION'
+ExecStop=/bin/sh -c "docker stop -t 3 %p-filter && docker stop -t 3 %p-http"
 Restart=on-failure
 RestartSec=60
 


### PR DESCRIPTION
Varnish has new log format that adds `User-Agent` and `Auth User` + switches
`Host` for `X-Forwarded-For`

Varnish changes here:
http://git.svc.ft.com/projects/CP/repos/api-component-policy-varnish/pull-requests/22/overview

Logfilter changes: https://github.com/Financial-Times/coco-logfilter/pull/22

Update splunk forwarder service to user versions/check history before
pulling, etc

### Deployments:

| env | date | 
|------|-------|
|xp   | Tue 14 Jun 09:03:40 BST 2016 |
|pre-prod| Tue 14 Jun 10:07:55 BST 2016|