### PR TITLE
remove the public-service front end that conflicts with cpr

### DIFF
--- a/document-store-api-sidekick@.service
+++ b/document-store-api-sidekick@.service
@@ -11,7 +11,6 @@ ExecStart=/bin/sh -c "\
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
   etcdctl set /ft/healthcheck/$SERVICE-%i/categories read; \
-  etcdctl set /vulcand/frontends/public-services-content/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`) && Host(`public-services`)\"}'; \
   etcdctl set /vulcand/frontends/public-services-lists/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-document-store-api\", \"Route\": \"PathRegexp(`/lists.*`) && Host(`public-services`)\"}'; \
   while [ -z $PORT ]; do \
     PORT=`echo $(/usr/bin/docker port $SERVICE-%i 8080 | cut -d':' -f2)`; \


### PR DESCRIPTION
needs manual removal

check this value is there
etcdctl get /vulcand/frontends/public-services-content/frontend

if so remove it
etcdctl rm /vulcand/frontends/public-services-content/frontend