### PR TITLE
Ack support for agg-hc

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -2,8 +2,9 @@ services:
 - name: aggregate-healthcheck-sidekick@.service
   count: 2
 - name: aggregate-healthcheck@.service
-  version: v1.0.8
+  version: ack-support
   count: 2
+  sequentialDeployment: true
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service

--- a/services.yaml
+++ b/services.yaml
@@ -2,7 +2,7 @@ services:
 - name: aggregate-healthcheck-sidekick@.service
   count: 2
 - name: aggregate-healthcheck@.service
-  version: ack-support
+  version: v1.1.0
   count: 2
   sequentialDeployment: true
 - name: api-policy-component-sidekick@.service


### PR DESCRIPTION
+ adding `sequentialDeployment` flag

**Note**: there is no GUI support to ACK a service, you have to do it manually, as described in https://github.com/Financial-Times/aggregate-healthcheck/blob/master/README.md