### PR TITLE
Whitelist neo4j backup

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -128,7 +128,7 @@ services:
   sequentialDeployment: true
 - name: fleet-unit-healthcheck-sidekick.service
 - name: fleet-unit-healthcheck.service
-  version: 1.0.2
+  version: 1.0.3
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-blue@.service

--- a/services.yaml
+++ b/services.yaml
@@ -128,7 +128,7 @@ services:
   sequentialDeployment: true
 - name: fleet-unit-healthcheck-sidekick.service
 - name: fleet-unit-healthcheck.service
-  version: 1.0.1
+  version: 1.0.2
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-blue@.service


### PR DESCRIPTION
* tested in `semantic`, works as excepted
* merged to `xp` too, but since neo4j-backup isn't there it did nothing
* will only push to `pre-prod` for now, `prod` after the ice age