### PR TITLE
Enabled Keepalive + connection reuse on the kafka-rest-proxy vulcan b…

### DIFF
--- a/kafka-rest-proxy-sidekick.service
+++ b/kafka-rest-proxy-sidekick.service
@@ -4,7 +4,7 @@ BindsTo=kafka-rest-proxy.service
 After=kafka-rest-proxy.service
 [Service]
 ExecStartPre=/bin/sh -c "\
-  etcdctl set /vulcand/backends/kafka-rest-proxy/backend '{\"Type\": \"http\"}' ; \
+  etcdctl set /vulcand/backends/kafka-rest-proxy/backend '{\"Type\": \"http\", \"Settings\": {\"KeepAlive\": {\"MaxIdleConnsPerHost\": 256, \"Period\": \"35s\"}}}' ; \
   etcdctl set /vulcand/frontends/kafka-rest-proxy/frontend '{\"Type\": \"http\", \"BackendId\": \"kafka-rest-proxy\", \"Route\": \"PathRegexp(`/.*`) && Host(`kafka`)\"}';"
 
 ExecStart=/bin/sh -c "\


### PR DESCRIPTION
…ackend
This change applied properly to all envs: https://github.com/Financial-Times/up-service-files/commit/7ab63766565193fa990b7c204d23c2b3c8b7b8de
Tried in XP and semantic, works.