### PR TITLE
Include videos in notifications feed

### DIFF
--- a/notifications-rw-sidekick@.service
+++ b/notifications-rw-sidekick@.service
@@ -4,17 +4,23 @@ BindsTo=notifications-rw@%i.service
 After=notifications-rw@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
-  etcdctl set ft/services/notifications-rw/healthcheck true; \
-  etcdctl mkdir /ft/services/notifications-rw/servers; \
-  etcdctl set /ft/healthcheck/notifications-rw-%i/path /__health; \
-  etcdctl set /vulcand/frontends/public-services-notifications/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-notifications-rw\", \"Route\": \"PathRegexp(`/content/notifications.*`) && Host(`public-services`)\"}'; \
-  while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port notifications-rw-%i 8080 | cut -d':' -f2)`; \
-    etcdctl set /ft/services/notifications-rw/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
-    sleep 120; \
-  done"
+  export SERVICE=$(echo %p | sed "s/-sidekick//g"); \
+  etcdctl set	/ft/services/$SERVICE/healthcheck	true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set	/ft/healthcheck/$SERVICE-%i/path	/__health; \
+  etcdctl set	/ft/healthcheck/$SERVICE-%i/categories	read; \
+  etcdctl set	/vulcand/frontends/public-services-notifications/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-$SERVICE\", \"Route\": \"PathRegexp(`/content/notifications.*`) && Host(`public-services`)\"}'; \
+  while [ -z $PORT ]; do \
+    PORT=`echo $(/usr/bin/docker port $SERVICE-%i 8080 | cut -d':' -f2)`; \
+    echo 'Port not set, retrying'; \
+    sleep 5; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
+
 ExecStop=/usr/bin/etcdctl rm /ft/services/notifications-rw/servers/%i
 
 [X-Fleet]
 MachineOf=notifications-rw@%i.service
+

--- a/services.yaml
+++ b/services.yaml
@@ -8,7 +8,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: v41
+  version: v43
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -266,7 +266,7 @@ services:
 - name: notifications-rw-sidekick@.service
   count: 2
 - name: notifications-rw@.service
-  version: v45
+  version: v46
   count: 2
   sequentialDeployment: true
 - name: organisations-rw-neo4j-blue-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -8,7 +8,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: v40
+  version: v41
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service
@@ -266,7 +266,7 @@ services:
 - name: notifications-rw-sidekick@.service
   count: 2
 - name: notifications-rw@.service
-  version: v44
+  version: v45
   count: 2
 - name: organisations-rw-neo4j-blue-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -268,6 +268,7 @@ services:
 - name: notifications-rw@.service
   version: v45
   count: 2
+  sequentialDeployment: true
 - name: organisations-rw-neo4j-blue-sidekick@.service
   count: 2
 - name: organisations-rw-neo4j-blue@.service


### PR DESCRIPTION
APC:
* added support for mediaResource policy (`INCLUDE_MEDIARESOURCE`) for notifications feed

Notifications-RW:
* added `type` query parameter for `/content/notifications` requests in notifications-rw
* use new sidekick format
* enabled sequential deployment
* let `java` be pid 1 in the running container

Testing:
* in progress