### PR TITLE
Increase Neo4j memory to 1GB to prevent OOM errors

### DIFF
--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -13,7 +13,7 @@ ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
 ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
 ExecStart=/bin/sh -c "\
-  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none neo4j:2.3.1"
+  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none neo4j:2.3.1 --env=NEO4J_HEAP_MEMORY=1024"
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure

--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -18,7 +18,7 @@ ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
 ExecStart=/bin/sh -c "\
   /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 \
     --env=NEO4J_AUTH=none \
-    --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
+    --env=NEO4J_HEAP_MEMORY=2048 neo4j:2.3.1"
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure

--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -12,6 +12,9 @@ KillMode=none
 ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
 ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
+
+# See neo4j-red@.service for the other neo4j instance
+# Also see https://neo4j.com/developer/docker-2-x/ for configuration options.
 ExecStart=/bin/sh -c "\
   /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
 

--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -13,7 +13,7 @@ ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
 ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
 ExecStart=/bin/sh -c "\
-  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none neo4j:2.3.1 --env=NEO4J_HEAP_MEMORY=1024"
+  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure

--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -13,10 +13,12 @@ ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
 ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
 
-# See neo4j-red@.service for the other neo4j instance
+# See neo4j-red@.service for the other neo4j instance.
 # Also see https://neo4j.com/developer/docker-2-x/ for configuration options.
 ExecStart=/bin/sh -c "\
-  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
+  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 \
+    --env=NEO4J_AUTH=none \
+    --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure

--- a/neo4j-red@.service
+++ b/neo4j-red@.service
@@ -13,7 +13,7 @@ ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
 ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
 ExecStart=/bin/sh -c "\
-  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none neo4j:2.3.1"
+  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none neo4j:2.3.1 --env=NEO4J_HEAP_MEMORY=1024"
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure

--- a/neo4j-red@.service
+++ b/neo4j-red@.service
@@ -18,7 +18,7 @@ ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
 ExecStart=/bin/sh -c "\
   /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 \
     --env=NEO4J_AUTH=none \
-    --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
+    --env=NEO4J_HEAP_MEMORY=2048 neo4j:2.3.1"
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure

--- a/neo4j-red@.service
+++ b/neo4j-red@.service
@@ -13,10 +13,12 @@ ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
 ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
 
-# See neo4j-blue@.service for the other neo4j instance
+# See neo4j-blue@.service for the other neo4j instance.
 # Also see https://neo4j.com/developer/docker-2-x/ for configuration options.
 ExecStart=/bin/sh -c "\
-  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
+  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 \
+    --env=NEO4J_AUTH=none \
+    --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure

--- a/neo4j-red@.service
+++ b/neo4j-red@.service
@@ -13,7 +13,7 @@ ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
 ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
 ExecStart=/bin/sh -c "\
-  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none neo4j:2.3.1 --env=NEO4J_HEAP_MEMORY=1024"
+  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
 
 ExecStop=/usr/bin/docker stop -t 3 %p-%i
 Restart=on-failure

--- a/neo4j-red@.service
+++ b/neo4j-red@.service
@@ -12,6 +12,9 @@ KillMode=none
 ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
 ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
+
+# See neo4j-blue@.service for the other neo4j instance
+# Also see https://neo4j.com/developer/docker-2-x/ for configuration options.
 ExecStart=/bin/sh -c "\
   /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 --env=NEO4J_AUTH=none --env=NEO4J_HEAP_MEMORY=1024 neo4j:2.3.1"
 


### PR DESCRIPTION
This is a small change that should prevent us from getting `OutOfMemoryError` crashes in the pre-prod environment. We're currently using the [the default](https://neo4j.com/developer/docker-2-x/) of 512MB; this increases heap to 1GB.

After the change, neo's `ps` output looks like this (`-D` flags moved to new lines for readability):

	root         1 14.6  5.1 5144800 852412 ?      Ssl  13:18   0:30 /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -cp /var/lib/neo4j/lib/commons-lang3-3.3.2.jar:/var/lib/neo4j/lib/concurrentlinkedhashmap-lru-1.4.2.jar:/var/lib/neo4j/lib/jline-2.12.jar:/var/lib/neo4j/lib/lucene-core-3.6.2.jar:/var/lib/neo4j/lib/neo4j-codegen-2.3.1.jar:/var/lib/neo4j/lib/neo4j-consistency-check-2.3.1.jar:/var/lib/neo4j/lib/neo4j-consistency-check-legacy-2.3.1.jar:/var/lib/neo4j/lib/neo4j-csv-2.3.1.jar:/var/lib/neo4j/lib/neo4j-cypher-2.3.1.jar:/var/lib/neo4j/lib/neo4j-cypher-compiler-1.9_2.11-2.0.5.jar:/var/lib/neo4j/lib/neo4j-cypher-compiler-2.2_2.11-2.2.6.jar:/var/lib/neo4j/lib/neo4j-cypher-compiler-2.3-2.3.1.jar:/var/lib/neo4j/lib/neo4j-cypher-frontend-2.3-2.3.1.jar:/var/lib/neo4j/lib/neo4j-function-2.3.1.jar:/var/lib/neo4j/lib/neo4j-graph-algo-2.3.1.jar:/var/lib/neo4j/lib/neo4j-graph-matching-2.3.1.jar:/var/lib/neo4j/lib/neo4j-import-tool-2.3.1.jar:/var/lib/neo4j/lib/neo4j-io-2.3.1.jar:/var/lib/neo4j/lib/neo4j-jmx-2.3.1.jar:/var/lib/neo4j/lib/neo4j-kernel-2.3.1.jar:/var/lib/neo4j/lib/neo4j-logging-2.3.1.jar:/var/lib/neo4j/lib/neo4j-lucene-index-2.3.1.jar:/var/lib/neo4j/lib/neo4j-primitive-collections-2.3.1.jar:/var/lib/neo4j/lib/neo4j-shell-2.3.1.jar:/var/lib/neo4j/lib/neo4j-udc-2.3.1.jar:/var/lib/neo4j/lib/neo4j-unsafe-2.3.1.jar:/var/lib/neo4j/lib/opencsv-2.3.jar:/var/lib/neo4j/lib/parboiled-core-1.1.7.jar:/var/lib/neo4j/lib/parboiled-scala_2.11-1.1.7.jar:/var/lib/neo4j/lib/scala-library-2.11.7.jar:/var/lib/neo4j/lib/scala-parser-combinators_2.11-1.0.4.jar:/var/lib/neo4j/lib/scala-reflect-2.11.7.jar:/var/lib/neo4j/lib/server-api-2.3.1.jar:/var/lib/neo4j/system/lib/asm-5.0.2.jar:/var/lib/neo4j/system/lib/bcpkix-jdk15on-1.52.jar:/var/lib/neo4j/system/lib/bcprov-jdk15on-1.52.jar:/var/lib/neo4j/system/lib/commons-beanutils-1.8.3.jar:/var/lib/neo4j/system/lib/commons-configuration-1.10.jar:/var/lib/neo4j/system/lib/commons-digester-2.1.jar:/var/lib/neo4j/system/lib/commons-io-2.4.jar:/var/lib/neo4j/system/lib/commons-lang-2.6.jar:/var/lib/neo4j/system/lib/commons-logging-1.1.1.jar:/var/lib/neo4j/system/lib/jackson-core-asl-1.9.13.jar:/var/lib/neo4j/system/lib/jackson-jaxrs-1.9.13.jar:/var/lib/neo4j/system/lib/jackson-mapper-asl-1.9.13.jar:/var/lib/neo4j/system/lib/javax.servlet-api-3.1.0.jar:/var/lib/neo4j/system/lib/jersey-core-1.19.jar:/var/lib/neo4j/system/lib/jersey-multipart-1.19.jar:/var/lib/neo4j/system/lib/jersey-server-1.19.jar:/var/lib/neo4j/system/lib/jersey-servlet-1.19.jar:/var/lib/neo4j/system/lib/jetty-http-9.2.4.v20141103.jar:/var/lib/neo4j/system/lib/jetty-io-9.2.4.v20141103.jar:/var/lib/neo4j/system/lib/jetty-security-9.2.4.v20141103.jar:/var/lib/neo4j/system/lib/jetty-server-9.2.4.v20141103.jar:/var/lib/neo4j/system/lib/jetty-servlet-9.2.4.v20141103.jar:/var/lib/neo4j/system/lib/jetty-util-9.2.4.v20141103.jar:/var/lib/neo4j/system/lib/jetty-webapp-9.2.4.v20141103.jar:/var/lib/neo4j/system/lib/jetty-xml-9.2.4.v20141103.jar:/var/lib/neo4j/system/lib/jsr311-api-1.1.2.r612.jar:/var/lib/neo4j/system/lib/logback-access-1.1.2.jar:/var/lib/neo4j/system/lib/logback-classic-1.1.2.jar:/var/lib/neo4j/system/lib/logback-core-1.1.2.jar:/var/lib/neo4j/system/lib/mimepull-1.9.3.jar:/var/lib/neo4j/system/lib/neo4j-browser-2.3.1.jar:/var/lib/neo4j/system/lib/neo4j-server-2.3.1-static-web.jar:/var/lib/neo4j/system/lib/neo4j-server-2.3.1.jar:/var/lib/neo4j/system/lib/netty-all-4.0.28.Final.jar:/var/lib/neo4j/system/lib/rhino-1.7R4.jar:/var/lib/neo4j/system/lib/rrd4j-2.2.jar:/var/lib/neo4j/system/lib/slf4j-api-1.7.6.jar:/var/lib/neo4j/conf -server -XX:+DisableExplicitGC 
	-Dorg.neo4j.server.properties=conf/neo4j-server.properties 
	-Dlog4j.configuration=file:conf/log4j.properties -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow -XX:hashCode=5 
	-Dneo4j.ext.udc.source=docker -Xms1024m -Xmx1024m 
	-Dneo4j.home=/var/lib/neo4j 
	-Dneo4j.instance=/var/lib/neo4j 
	-Dfile.encoding=UTF-8 org.neo4j.server.CommunityBootstrapper

The important bit: `-Xms1024m -Xmx1024m`
