### PR TITLE
UPP-1354 Change desiredState for neo4j-backup.service to be INACTIVE …

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -251,7 +251,7 @@ services:
   count: 2
   sequentialDeployment: true
 - name: neo4j-backup.service
-  desiredState: loaded
+  desiredState: inactive
   version: 0.8.1
 - name: neo4j-blue-sidekick@.service
   count: 1


### PR DESCRIPTION
…rather than LOADED, to avoid it running an undesired backup on machine boot.

This change is required to avoid neo4j-backup.service being automatically loaded onto the same box as neo4j-red@1.service, which, after that machine restarts, leads to the service being run automatically with unpleasant consequences. I am fixing a couple of the obvious code logic limitations within the neo4j-backup code, but we still do not want the service to execute on boot. The only way I could find to achieve this is for fleet to initially load the service as INACTIVE; when you run `fleetctl start neo4j-backup.service`, everything will run just fine.

After issuing `fleetctl destroy neo4j-backup.service`, I get the following:

```
[dafydd ~][pre-prod]$ fleetctl list-unit-files | grep ^neo4j-backup
neo4j-backup.service						de881cf	inactive	inactive	-
```