### PR TITLE
Updated the version of the org-rw to be the final version

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -290,7 +290,7 @@ services:
 - name: organisations-rw-neo4j-red-sidekick@.service
   count: 1
 - name: organisations-rw-neo4j-red@.service
-  version: v0.2.1
+  version: v0.2.0
   count: 1
 - name: os-upgrade.service
   desiredState: loaded


### PR DESCRIPTION
We had to release a temporary version of the org-rw that went through and handled all the parent organisations first. However this is the final version .

https://github.com/Financial-Times/organisations-rw-neo4j/releases/tag/0.2.0