### PR TITLE
Bump PAM version.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -353,7 +353,7 @@ services:
 - name: publish-availability-monitor-sidekick@.service
   count: 1
 - name: publish-availability-monitor@.service
-  version: v0.19.1
+  version: v0.20.1
   count: 1
 - name: restorage-mongo-sidekick@.service
   count: 1


### PR DESCRIPTION
EOM::Story with "Financial Times" channel is valid for publication, so non-synthetic requests should be monitored.