### PR TITLE
Bump WPIM version.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -527,6 +527,6 @@ services:
 - name: wordpress-image-mapper-sidekick@.service
   count: 2
 - name: wordpress-image-mapper@.service
-  version: v27
+  version: v31
   count: 2
 - name: zookeeper.service


### PR DESCRIPTION
Switch to passive consumer healthcheck; don't throw InterruptedException on normal shutdown.