### PR TITLE
Fixed to the right version v0.2.0 of org-rw as mistakedly got removed

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -285,7 +285,7 @@ services:
 - name: organisations-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: organisations-rw-neo4j-blue@.service
-  version: v0.2.1
+  version: v0.2.0
   count: 1
 - name: organisations-rw-neo4j-red-sidekick@.service
   count: 1


### PR DESCRIPTION
During a merge conflict the wrong version ended up in the org-rw (should be 0.2.0)

(Previous PR: https://github.com/Financial-Times/up-service-files/pull/687)