### PR TITLE
Fix version of mongo-backup service.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -242,6 +242,7 @@ services:
   count: 2
 - name: methodeapi-endpoint.service
 - name: mongo-backup.service
+  version: v13
   desiredState: loaded
 - name: mongo-backup.timer
 - name: mongodb-configurator.service


### PR DESCRIPTION
Fix the version number so that later merges for the service aren't picked up until desired.
The most recent Jenkins build was v13 so I tagged the Docker image as such (I am not sure why it wasn't already tagged, in Jenkins it looks like it should be). The intended effect of this PR is in fact "no change".