### PR TITLE
Unique container names persistence units

### DIFF
--- a/mongodb-configurator.service
+++ b/mongodb-configurator.service
@@ -11,9 +11,10 @@ TimeoutStartSec=0
 KillMode=none
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=-/bin/bash -c "/usr/bin/docker kill %p > /dev/null 2>&1"
-ExecStartPre=-/bin/bash -c "/usr/bin/docker rm %p > /dev/null 2>&1"
-ExecStartPre=/bin/bash -c "/usr/bin/docker pull coco/coco-mongodb-configurator:$DOCKER_APP_VERSION"
+ExecStartPre=-/bin/bash -c "/usr/bin/docker kill "$(docker ps -q --filter=name=%p_)" > /dev/null 2>&1"
+ExecStartPre=-/bin/bash -c "/usr/bin/docker rm "$(docker ps -q --filter=name=%p_)" > /dev/null 2>&1"
+ExecStartPre=/bin/bash -c 'docker history coco/coco-mongodb-configurator:$DOCKER_APP_VERSION > /dev/null 2>&1 || docker pull coco/coco-mongodb-configurator:$DOCKER_APP_VERSION'
+
 ExecStart=/bin/bash -c '\
     EXPECTED_MONGOS=3; \
     echo "INFO Waiting for all mongodb instances to start"; \
@@ -38,6 +39,9 @@ ExecStart=/bin/bash -c '\
       echo "INFO Still waiting for all mongodb instances to start"; \
     done; \
     echo "INFO Got all instances, configuring mongodb cluster"; \
-    docker run --rm --name %p --env="ARGS=$ALL" coco/coco-mongodb-configurator:$DOCKER_APP_VERSION;'
-ExecStop=/usr/bin/docker stop -t 3 %p
+    docker run --rm --name %p_$(uuidgen) \
+        --env="ARGS=$ALL" \
+        coco/coco-mongodb-configurator:$DOCKER_APP_VERSION;'
+
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p_)"'
 

--- a/mongodb-sidekick@.service
+++ b/mongodb-sidekick@.service
@@ -4,18 +4,23 @@ BindsTo=mongodb@%i.service
 After=mongodb@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
-  export MONGODB_IP=$HOSTNAME; \
-  while true; do \
-    MONGODB_PORT=`[ $MONGODB_PORT ] && echo $MONGODB_PORT || echo $(/usr/bin/docker port mongodb-%i 27017 | cut -d':' -f2)`; \
-    MONGODB_ADMIN_PORT=`[ $MONGODB_ADMIN_PORT ] && echo $MONGODB_ADMIN_PORT || echo $(/usr/bin/docker port mongodb-%i 28017 | cut -d':' -f2)`; \
-    etcdctl mkdir /ft/config/mongodb/%i --ttl 600; \
-    etcdctl set /ft/config/mongodb/%i/host $MONGODB_IP --ttl 600; \
-    etcdctl set /ft/config/mongodb/%i/port $MONGODB_PORT --ttl 600; \
-    etcdctl set /ft/config/mongodb/%i/admin_port $MONGODB_ADMIN_PORT --ttl 600; \
-    sleep 120; \
-  done"
-ExecStop=/usr/bin/etcdctl rm --recursive /ft/config/mongodb/%i
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl mkdir /ft/config/$SERVICE/%i; \
+  etcdctl set /ft/config/$SERVICE/%i/host $HOSTNAME; \
+  while [ -z $PORT ] || [ -z $ADMIN_PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 27017 | cut -d':' -f2)`; \
+    ADMIN_PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 28017 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/config/$SERVICE/%i/port $PORT; \
+  etcdctl set /ft/config/$SERVICE/%i/admin_port $ADMIN_PORT;"
+
+ExecStop=-/bin/bash -c 'etcdctl rm --recursive /ft/config/mongodb/%i'
+Restart=on-failure
+RestartSec=60
 
 [X-Fleet]
 MachineOf=mongodb@%i.service

--- a/mongodb@.service
+++ b/mongodb@.service
@@ -5,18 +5,25 @@ Requires=docker.service
 Wants=mongodb-sidekick@%i.service
 
 [Service]
+Environment="DOCKER_APP_VERSION=latest"
 TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
-ExecStartPre=/usr/bin/docker pull coco/mongodb
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker history coco/mongodb:$DOCKER_APP_VERSION > /dev/null 2>&1 || docker pull coco/mongodb:$DOCKER_APP_VERSION'
+
 ExecStart=/bin/sh -c "\
   MONGO_PORT=27017;\
   MONGO_ADMIN_PORT=$(( $MONGO_PORT + 1000));\
-  /usr/bin/docker run --rm --name %p-%i -v /vol/mongodb:/data/db -p $(( $MONGO_PORT + %i )):$MONGO_PORT -p $(( $MONGO_ADMIN_PORT + %i )):$MONGO_ADMIN_PORT coco/mongodb;"
-ExecStop=/usr/bin/docker stop -t 3 %p-%i
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) \
+  -v /vol/mongodb:/data/db \
+  -p $(( $MONGO_PORT + %i )):$MONGO_PORT \
+  -p $(( $MONGO_ADMIN_PORT + %i )):$MONGO_ADMIN_PORT \
+  coco/mongodb:$DOCKER_APP_VERSION;"
+
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
 Restart=on-failure
 RestartSec=60
 

--- a/neo4j-blue-sidekick@.service
+++ b/neo4j-blue-sidekick@.service
@@ -4,15 +4,19 @@ BindsTo=neo4j-blue@%i.service
 After=neo4j-blue@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
-  etcdctl mkdir /ft/services/neo4j-blue/servers; \
-  etcdctl set /vulcand/frontends/neo4j-blue-db/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-neo4j-blue\", \"Route\": \"HeaderRegexp(`Referer`, `.*__neo4j-blue.*`)\", \"Settings\": { \"TrustForwardHeader\": true, \"PassHostHeader\": true }}'; \
-  while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port neo4j-blue-%i 7474 | cut -d':' -f2)`; \
-    etcdctl set /ft/services/neo4j-blue/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
-    sleep 120; \
-  done"
-ExecStop=/usr/bin/etcdctl rm /ft/services/neo4j-blue/servers/%i
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /vulcand/frontends/$SERVICE-db/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-neo4j-blue\", \"Route\": \"HeaderRegexp(`Referer`, `.*__neo4j-blue.*`)\", \"Settings\": { \"TrustForwardHeader\": true, \"PassHostHeader\": true }}'; \
+  while [ -z $PORT ]; do \
+     sleep 5; \
+     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+     PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 7474 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
+
+ExecStop=-/bin/bash -c 'etcdctl rm /ft/services/neo4j-blue/servers/%i'
 
 [X-Fleet]
 MachineOf=neo4j-blue@%i.service

--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -9,18 +9,19 @@ TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
-ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker history neo4j:$DOCKER_APP_VERSION > /dev/null 2>&1 || docker pull neo4j:$DOCKER_APP_VERSION'
 
 # See neo4j-red@.service for the other neo4j instance.
 # Also see https://neo4j.com/developer/docker-2-x/ for configuration options.
 ExecStart=/bin/sh -c "\
-  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 \
+    /usr/bin/docker run --rm --name %p-%i_$(uuidgen) \
+    -v /vol/%p-%i/:/data -p 7474:7474 \
     --env=NEO4J_AUTH=none \
-    --env=NEO4J_HEAP_MEMORY=4096 neo4j:2.3.1"
+    --env=NEO4J_HEAP_MEMORY=4096 neo4j:$DOCKER_APP_VERSION"
 
-ExecStop=/usr/bin/docker stop -t 3 %p-%i
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
 Restart=on-failure
 RestartSec=60
 

--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -5,6 +5,7 @@ Requires=docker.service
 Wants=neo4j-blue-sidekick@%i.service neo4j-read-blue-sidekick@%i.service
 
 [Service]
+Environment="DOCKER_APP_VERSION=latest"
 TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.

--- a/neo4j-read-blue-sidekick@.service
+++ b/neo4j-read-blue-sidekick@.service
@@ -11,12 +11,13 @@ ExecStart=/bin/sh -c '\
    etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
    etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
    while [ -z $PORT ]; do \
-     PORT=`echo $(/usr/bin/docker port neo4j-blue-%i 7474 | cut -d":" -f2)`; \
-     echo "Port not set, retrying"; \
      sleep 5; \
+     CONTAINER_NAME=$(docker ps -q --filter=name=neo4j-blue-%i_); \
+     PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 7474 | cut -d':' -f2)`; \
    done; \
    etcdctl set /vulcand/backends/neo4j-read/servers/2 "{\\"url\\": \\"http://$HOSTNAME:$PORT\\"}"'
-ExecStop=/usr/bin/etcdctl rm /vulcand/backends/neo4j-read/servers/2
+
+ExecStop=-/bin/bash -c 'etcdctl rm /vulcand/backends/neo4j-read/servers/2'
 
 [X-Fleet]
 MachineOf=neo4j-blue@%i.service

--- a/neo4j-read-red-sidekick@.service
+++ b/neo4j-read-red-sidekick@.service
@@ -11,12 +11,13 @@ ExecStart=/bin/sh -c '\
   etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
   etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
   while [ -z $PORT ]; do \
-    PORT=`echo $(/usr/bin/docker port neo4j-red-%i 7474 | cut -d":" -f2)`; \
-    echo "Port not set, retrying"; \
     sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=neo4j-red-%i_); \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 7474 | cut -d":" -f2)`; \
   done; \
   etcdctl set /vulcand/backends/neo4j-read/servers/1 "{\\"url\\": \\"http://$HOSTNAME:$PORT\\"}"'
-ExecStop=/usr/bin/etcdctl rm /vulcand/backends/neo4j-read/servers/1
+
+ExecStop=-/bin/bash -c 'etcdctl rm /vulcand/backends/neo4j-read/servers/1'
 
 [X-Fleet]
 MachineOf=neo4j-red@%i.service

--- a/neo4j-red-sidekick@.service
+++ b/neo4j-red-sidekick@.service
@@ -4,15 +4,19 @@ BindsTo=neo4j-red@%i.service
 After=neo4j-red@%i.service
 
 [Service]
+RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
-  etcdctl mkdir /ft/services/neo4j-red/servers; \
-  etcdctl set /vulcand/frontends/neo4j-red-db/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-neo4j-red\", \"Route\": \"HeaderRegexp(`Referer`, `.*__neo4j-red.*`)\", \"Settings\": { \"TrustForwardHeader\": true, \"PassHostHeader\": true }}'; \
-  while true; do \
-    PORT=`[ $PORT ] && echo $PORT || echo $(/usr/bin/docker port neo4j-red-%i 7474 | cut -d':' -f2)`; \
-    etcdctl set /ft/services/neo4j-red/servers/%i "http://$HOSTNAME:$PORT" --ttl 600; \
-    sleep 120; \
-  done"
-ExecStop=/usr/bin/etcdctl rm /ft/services/neo4j-red/servers/%i
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /vulcand/frontends/$SERVICE-db/frontend '{\"Type\": \"http\", \"BackendId\": \"vcb-neo4j-red\", \"Route\": \"HeaderRegexp(`Referer`, `.*__neo4j-red.*`)\", \"Settings\": { \"TrustForwardHeader\": true, \"PassHostHeader\": true }}'; \
+  while [ -z $PORT ]; do \
+     sleep 5; \
+     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+     PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 7474 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
+
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/neo4j-red/servers/%i'
 
 [X-Fleet]
 MachineOf=neo4j-red@%i.service

--- a/neo4j-red@.service
+++ b/neo4j-red@.service
@@ -5,22 +5,24 @@ Requires=docker.service
 Wants=neo4j-red-sidekick@%i.service neo4j-read-red-sidekick@%i.service
 
 [Service]
+Environment="DOCKER_APP_VERSION=latest"
 TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p-%i > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p-%i > /dev/null 2>&1'
-ExecStartPre=/usr/bin/docker pull neo4j:2.3.1
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker history neo4j:$DOCKER_APP_VERSION > /dev/null 2>&1 || docker pull neo4j:$DOCKER_APP_VERSION'
 
 # See neo4j-blue@.service for the other neo4j instance.
 # Also see https://neo4j.com/developer/docker-2-x/ for configuration options.
 ExecStart=/bin/sh -c "\
-  /usr/bin/docker run --rm --name %p-%i -v /vol/%p-%i/:/data -p 7474:7474 \
+    /usr/bin/docker run --rm --name %p-%i_$(uuidgen) \
+    -v /vol/%p-%i/:/data -p 7474:7474 \
     --env=NEO4J_AUTH=none \
-    --env=NEO4J_HEAP_MEMORY=4096 neo4j:2.3.1"
+    --env=NEO4J_HEAP_MEMORY=4096 neo4j:$DOCKER_APP_VERSION"
 
-ExecStop=/usr/bin/docker stop -t 3 %p-%i
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
 Restart=on-failure
 RestartSec=60
 

--- a/services.yaml
+++ b/services.yaml
@@ -268,6 +268,7 @@ services:
 - name: neo4j-blue-sidekick@.service
   count: 1
 - name: neo4j-blue@.service
+  version: 2.3.1
   count: 1
 - name: neo4j-read-blue-sidekick@.service
   count: 1
@@ -276,6 +277,7 @@ services:
 - name: neo4j-red-sidekick@.service
   count: 1
 - name: neo4j-red@.service
+  version: 2.3.1
   count: 1
 - name: notifications-ingester-sidekick@.service
   count: 2


### PR DESCRIPTION
Fixing "container already in use" and "port not being set" issues for persistence units.
(See https://jira.ft.com/browse/UPP-1385 and https://jira.ft.com/browse/UPP-1390 for more details.)

Some service file refactoring was also made.

Tested in XP.

:warning: Note: these changes will require failover while deploying
