### PR TITLE
Vulcan config builder v1.3.0 

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -526,7 +526,7 @@ services:
   version: v1.2.0
   count: 2
 - name: vulcan-config-builder.service
-  version: v1.2.2
+  version: v1.3.0
 - name: vulcan.service
   version: v1.2.2
 - name: wordpress-article-transformer-sidekick@.service


### PR DESCRIPTION
No failover predicate by default which means no retries on error

https://github.com/Financial-Times/vulcan-config-builder/pull/17