### PR TITLE
Removed unused frontends. Varnish is doing this routing.

### DIFF
--- a/aggregate-healthcheck-sidekick@.service
+++ b/aggregate-healthcheck-sidekick@.service
@@ -8,8 +8,6 @@ RemainAfterExit=yes
 ExecStart=/bin/sh -c "\
   export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
-  etcdctl set /vulcand/frontends/aggregate-healthcheck-public/frontend '{\"Type\":\"http\", \"BackendId\":\"vcb-aggregate-healthcheck\", \"Route\":\"Path(`/__health`)\"}'; \
-  etcdctl set /vulcand/frontends/aggregate-healthcheck-public-gtg/frontend '{\"Type\":\"http\", \"BackendId\":\"vcb-aggregate-healthcheck\", \"Route\":\"Path(`/__gtg`)\"}'; \
   etcdctl set /ft/healthcheck-categories/read/period_seconds 4; \
   etcdctl set /ft/healthcheck-categories/read/is_resilient true; \
   etcdctl set /ft/healthcheck-categories/system/period_seconds 60; \


### PR DESCRIPTION
Varnish routing: http://git.svc.ft.com/projects/CP/repos/api-component-policy-varnish/browse/default.vcl#22

Tested in XP