### PR TITLE
Upgrade vulcan config builder

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -536,7 +536,7 @@ services:
   version: v1.2.0
   count: 2
 - name: vulcan-config-builder.service
-  version: v1.3.0
+  version: v1.3.1
 - name: vulcan.service
   version: v1.2.2
 - name: wordpress-article-transformer-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -536,7 +536,7 @@ services:
   version: v1.2.0
   count: 2
 - name: vulcan-config-builder.service
-  version: v1.3.1
+  version: v1.3.2
 - name: vulcan.service
   version: v1.2.2
 - name: wordpress-article-transformer-sidekick@.service


### PR DESCRIPTION
Upgrade vulcan config builder to v1.3.1 which contains better logging
when invalid servers are discovered in backends.

UPDATE: Upgraded to version v1.3.2, supporting custom Host along with path regex https://github.com/Financial-Times/vulcan-config-builder/releases/tag/v1.3.2