### PR TITLE
Decouple annotations API errors from enriched content API.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -133,7 +133,7 @@ services:
 - name: enriched-content-read-api-sidekick@.service
   count: 2
 - name: enriched-content-read-api@.service
-  version: v61
+  version: v63
   count: 2
   sequentialDeployment: true
 - name: fleet-unit-healthcheck-sidekick.service


### PR DESCRIPTION
Annotation API errors will no longer cause the Enriched Content API to error, it will just return an empty array