### PR TITLE
Fleet unit hc whitelist regex

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -150,7 +150,7 @@ services:
 - name: fleet-unit-healthcheck-sidekick@.service
   count: 1
 - name: fleet-unit-healthcheck@.service
-  version: 1.0.6
+  version: 1.0.7
   count: 1
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -150,7 +150,7 @@ services:
 - name: fleet-unit-healthcheck-sidekick@.service
   count: 1
 - name: fleet-unit-healthcheck@.service
-  version: 1.0.3
+  version: 1.0.6
   count: 1
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1


### PR DESCRIPTION
Allows the fleet-unit-healthcheck to whitelist `mongo-backup@.service`. Tested in dynpub,