### PR TITLE
Revert fleet-unit-healthcheck version.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -150,7 +150,7 @@ services:
 - name: fleet-unit-healthcheck-sidekick@.service
   count: 1
 - name: fleet-unit-healthcheck@.service
-  version: 1.0.7
+  version: 1.0.5
   count: 1
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1


### PR DESCRIPTION
Switch back in prod to the version of fleet-unit-healthcheck that will be healthy for the singleton mongo-backup service.