### PR TITLE
Restrict alt titles according to policy.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -18,7 +18,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: v43
+  version: v52
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service


### PR DESCRIPTION
Intermediate build numbers were all broken builds.
See
http://git.svc.ft.com/projects/CP/repos/api-policy-component/pull-requests/76/overview