### PR TITLE
Lower resource usage by mongodb backup

### DIFF
--- a/mongo-backup.service
+++ b/mongo-backup.service
@@ -38,8 +38,9 @@ ExecStart=/bin/sh -c "\
         -e DATA_FOLDER=$DATA_FOLDER \
         -e S3_DOMAIN=$S3_DOMAIN \
         -e ENV_TAG=$ENV_TAG \
+        --memory="1g" \
         -v /vol/mongodb:$DATA_FOLDER \
-        up-registry.ft.com/coco/mongodb-backup:$DOCKER_APP_VERSION; "
+        coco/coco-mongodb-backup:$DOCKER_APP_VERSION; "
 
 Nice=10
 

--- a/services.yaml
+++ b/services.yaml
@@ -246,7 +246,7 @@ services:
   version: v27
   count: 2
 - name: mongo-backup.service
-  version: v13
+  version: v14.0.0
   desiredState: loaded
 - name: mongo-backup.timer
 - name: mongodb-configurator.service

--- a/services.yaml
+++ b/services.yaml
@@ -246,7 +246,7 @@ services:
   version: v27
   count: 2
 - name: mongo-backup@.service
-  version: v14.0.0
+  version: v20.0.0
   desiredState: loaded
   count: 3
 - name: mongo-backup@.timer


### PR DESCRIPTION
Use newer version which uses newer Go version and had simplified code,
both of which reduce CPU overhead.

Also, limit memory to 1g in the docker command.