### PR TITLE
Fleet unit hc mongo backup

### DIFF
--- a/mongo-backup.service
+++ b/mongo-backup.service
@@ -2,10 +2,6 @@
 Description=Job to backup mongo DB data files to S3
 
 [Service]
-# process will be short-lived and that systemd should wait for the process to
-# exit before continuing on with other units.
-Type=oneshot
-
 Environment="DOCKER_APP_VERSION=latest"
 
 # should start up instantly, so start timeout can be 0

--- a/services.yaml
+++ b/services.yaml
@@ -150,7 +150,7 @@ services:
 - name: fleet-unit-healthcheck-sidekick@.service
   count: 1
 - name: fleet-unit-healthcheck@.service
-  version: 1.0.5
+  version: 1.0.7
   count: 1
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1


### PR DESCRIPTION
- Deploy fleet-unit-healthcheck 1.0.7 to allow whitelisting of multiple mongo-backup service instances.
- Remove "type=oneshot" from mongo-backup so that it is listed as "active" rather than "activating" when running, so that normal operation doesn't trigger a warning in the fleet-unit-healthcheck.