### PR TITLE
Pin org r/w apps to corresponding neo instances.

### DIFF
--- a/organisations-rw-neo4j-blue@.service
+++ b/organisations-rw-neo4j-blue@.service
@@ -30,3 +30,4 @@ RestartSec=60
 
 [X-Fleet]
 Conflicts=organisations-rw-neo4j-blue@*.service
+MachineOf=neo4j-blue@%i.service

--- a/organisations-rw-neo4j-red@.service
+++ b/organisations-rw-neo4j-red@.service
@@ -30,4 +30,5 @@ RestartSec=60
 
 [X-Fleet]
 Conflicts=organisations-rw-neo4j-red@*.service
+MachineOf=neo4j-red@%i.service
 


### PR DESCRIPTION
Put org r/w apps to the same machines as their neo4j instances.
Whether to put these on the same machine as neo4j is a tradeoff.
Using a different machine reduces resource contention, and using the
same machine reduces inter-vm networking.
I have ovserved that the ingests go slowly when on different vms, and
putting them on the same machine makes things significantly faster.
In practice, resource contention on the neo4j machine is mininal because
the org r/w app uses very little memory of CPU.