### PR TITLE
Bumped the version for the content-rw to create the brand identifiers

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -123,12 +123,12 @@ services:
 - name: content-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: content-rw-neo4j-blue@.service
-  version: v0.0.33
+  version: v0.0.34
   count: 1
 - name: content-rw-neo4j-red-sidekick@.service
   count: 1
 - name: content-rw-neo4j-red@.service
-  version: v0.0.33
+  version: v0.0.34
   count: 1
 - name: diamond.service
 - name: document-store-api-sidekick@.service


### PR DESCRIPTION
The brands UPPIdentifiers needed to be written when the content comes in with an unknown brand. Additionally I have also done the changes to use the new neoutils package. More details here: https://github.com/Financial-Times/content-rw-neo4j/pull/8