### PR TITLE
Add configurable timeout to api policy component

### DIFF
--- a/api-policy-component@.service
+++ b/api-policy-component@.service
@@ -22,6 +22,7 @@ ExecStart=/bin/sh -c '\
   --env "READ_ENDPOINT=$HOSTNAME:8080:8182" \
   --env "GRAPHITE_HOST=graphite.ft.com" \
   --env "GRAPHITE_PORT=2003" \
+  --env "JERSEY_TIMEOUT_MS=10000" \
   --env "GRAPHITE_PREFIX=coco.services.$ENV.api-policy-component.%i" \
   up-registry.ft.com/coco/api-policy-component:$DOCKER_APP_VERSION'
 ExecStop=-/bin/bash -c '/usr/bin/docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/api-policy-component@.service
+++ b/api-policy-component@.service
@@ -22,7 +22,7 @@ ExecStart=/bin/sh -c '\
   --env "READ_ENDPOINT=$HOSTNAME:8080:8182" \
   --env "GRAPHITE_HOST=graphite.ft.com" \
   --env "GRAPHITE_PORT=2003" \
-  --env "JERSEY_TIMEOUT_MS=10000" \
+  --env "JERSEY_TIMEOUT_DURATION=10000ms" \
   --env "GRAPHITE_PREFIX=coco.services.$ENV.api-policy-component.%i" \
   up-registry.ft.com/coco/api-policy-component:$DOCKER_APP_VERSION'
 ExecStop=-/bin/bash -c '/usr/bin/docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/services.yaml
+++ b/services.yaml
@@ -18,7 +18,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: v52
+  version: v54
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service


### PR DESCRIPTION
The latest build of api policy component passes an env variable in the docker file. This commit sets that value. 