### PR TITLE
Allow neo4j some more memory

### DIFF
--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -18,7 +18,7 @@ ExecStartPre=/bin/bash -c 'docker history coco/ft-neo4j:$DOCKER_APP_VERSION > /d
 # Also see https://neo4j.com/developer/docker-2-x/ for configuration options.
 ExecStart=/bin/sh -c "\
     /usr/bin/docker run --rm --name %p-%i_$(uuidgen) \
-    --memory="4g" \
+    --memory="5g" \
     -v /vol/%p-%i/:/data -p 7474:7474 \
     --env=NEO4J_AUTH=none \
     --env=NEO4J_HEAP_MEMORY=2048 \

--- a/neo4j-red@.service
+++ b/neo4j-red@.service
@@ -18,7 +18,7 @@ ExecStartPre=/bin/bash -c 'docker history coco/ft-neo4j:$DOCKER_APP_VERSION > /d
 # Also see https://neo4j.com/developer/docker-2-x/ for configuration options.
 ExecStart=/bin/sh -c "\
     /usr/bin/docker run --rm --name %p-%i_$(uuidgen) \
-    --memory="4g" \
+    --memory="5g" \
     -v /vol/%p-%i/:/data -p 7474:7474 \
     --env=NEO4J_AUTH=none \
     --env=NEO4J_HEAP_MEMORY=2048 \


### PR DESCRIPTION
We have the JVM heap set to 2G and cache set to 2G, and hard container
limit set to 4G. This leaves no overhead for the JVM or anything else.