### PR TITLE
Separate CoreOS version check from system healthcheck.

### DIFF
--- a/coreos-version-checker-sidekick.service
+++ b/coreos-version-checker-sidekick.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=System CoreOS version monitoring sidekick
+BindsTo=coreos-version-checker.service
+After=coreos-version-checker.service
+
+[Service]
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "\
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl set /vulcand/backends/coreos-version-checker-%H/backend '{\"Type\": \"http\"}'; \
+  etcdctl set /vulcand/frontends/coreos-version-checker-%H/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"coreos-version-checker-%H\\\", \\\"Route\\\":\\\"Path(\`/health/coreos-version-checker-%H/__health\`)\\\"}\"; \
+  etcdctl set /vulcand/frontends/coreos-version-checker-%H/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/coreos-version-checker-%H(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
+  etcdctl set /ft/healthcheck/coreos-version-checker-%H/path /__health; \
+  etcdctl set /ft/healthcheck/coreos-version-checker-%H/categories system; \
+  while [ -z $PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"_); \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /vulcand/backends/coreos-version-checker-%H/servers/srv%H \"{\\\"url\\\": \\\"http://$HOSTNAME:$PORT\\\"}\";"
+
+ExecStop=-/bin/bash -c 'etcdctl rm /vulcand/backends/coreos-version-checker-%H/servers/srv%H'
+
+[X-Fleet]
+Global=true

--- a/coreos-version-checker.service
+++ b/coreos-version-checker.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=System CoreOS version monitoring service
+Requires=docker.socket
+After=docker.socket
+Wants=coreos-version-checker-sidekick.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest" "SYS_HC_HOST_PATH=host_dir"
+ExecStartPre=-/usr/bin/docker kill "$(docker ps -q --filter=name=%p_)"
+ExecStartPre=-/usr/bin/docker rm "$(docker ps -q --filter=name=%p_)"
+ExecStartPre=/bin/sh -c "docker history coco/coreos-version-checker:$DOCKER_APP_VERSION >/dev/null 2>&1 || docker pull coco/coreos-version-checker:$DOCKER_APP_VERSION"
+ExecStart=/bin/sh -c "/usr/bin/docker run --rm --name %p_$(uuidgen) \
+    -P \
+    -e SYS_HC_HOST_PATH=$SYS_HC_HOST_PATH \
+    -v /:/$SYS_HC_HOST_PATH:ro \
+    coco/coreos-version-checker:$DOCKER_APP_VERSION"
+
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p_)"'
+Restart=on-failure
+RestartSec=60
+
+[Install]
+WantedBy=multi-user.target
+
+[X-Fleet]
+Global=true

--- a/services.yaml
+++ b/services.yaml
@@ -130,6 +130,9 @@ services:
 - name: content-rw-neo4j-red@.service
   version: v0.0.34
   count: 1
+- name: coreos-version-checker-sidekick.service
+- name: coreos-version-checker.service
+  version: v1.0.0
 - name: diamond.service
 - name: document-store-api-sidekick@.service
   count: 2
@@ -247,8 +250,8 @@ services:
   count: 2
 - name: mongo-backup@.service
   version: v20.0.0
-  desiredState: loaded
   count: 3
+  desiredState: loaded
 - name: mongo-backup@.timer
   count: 3
 - name: mongodb-configurator.service
@@ -444,7 +447,7 @@ services:
   count: 1
 - name: system-healthcheck-sidekick.service
 - name: system-healthcheck.service
-  version: 1.0.1
+  version: 1.0.2
 - name: topics-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: topics-rw-neo4j-blue@.service


### PR DESCRIPTION
Remove CoreOS version check from system healthchecks, and add it as a separate app. 

Look for the code changes [here](https://github.com/Financial-Times/coco-system-healthcheck/pull/38) and [here](https://github.com/Financial-Times/coreos-version-checker).

Tested in xp.

