### PR TITLE
Extend api-policy-component with request metrics

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -18,7 +18,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: v54
+  version: v56
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service


### PR DESCRIPTION
This version of APC allows us having request statistics for /concordances and /things endpoints in Grafana. 

Tested in XP.