### PR TITLE
Extend read categories

### DIFF
--- a/aggregate-healthcheck-sidekick@.service
+++ b/aggregate-healthcheck-sidekick@.service
@@ -16,6 +16,12 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/healthcheck-categories/lists-publish/is_resilient false; \
   etcdctl set /ft/healthcheck-categories/system/period_seconds 60; \
   etcdctl set /ft/healthcheck-categories/system/is_resilient false; \
+  etcdctl set /ft/healthcheck-categories/content-read/period_seconds 60; \
+  etcdctl set /ft/healthcheck-categories/content-read/is_resilient false; \
+  etcdctl set /ft/healthcheck-categories/enrichedcontent-read/period_seconds 60; \
+  etcdctl set /ft/healthcheck-categories/enrichedcontent-read/is_resilient false; \
+  etcdctl set /ft/healthcheck-categories/concordances-read/period_seconds 60; \
+  etcdctl set /ft/healthcheck-categories/concordances-read/is_resilient false; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \

--- a/api-policy-component-sidekick@.service
+++ b/api-policy-component-sidekick@.service
@@ -10,7 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
-  etcdctl set /ft/healthcheck/$SERVICE-%i/categories read,lists-read; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/categories read,lists-read,concordances-read,enrichedcontent-read,content-read; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \

--- a/content-public-read-preview-sidekick@.service
+++ b/content-public-read-preview-sidekick@.service
@@ -10,7 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set 	/ft/services/$SERVICE/healthcheck 		true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set 	/ft/healthcheck/$SERVICE-%i/path 		/__health; \
-  etcdctl set 	/ft/healthcheck/$SERVICE-%i/categories 	read; \
+  etcdctl set 	/ft/healthcheck/$SERVICE-%i/categories 	read,content-read; \
   etcdctl set   /ft/services/$SERVICE/path-regex/public-services /content-preview/.*; \
   etcdctl set   /ft/services/$SERVICE/path-host/public-services public-services; \
   while [ -z $PORT ]; do \

--- a/content-public-read-sidekick@.service
+++ b/content-public-read-sidekick@.service
@@ -10,7 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set 	/ft/services/$SERVICE/healthcheck 		true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set 	/ft/healthcheck/$SERVICE-%i/path 		/__health; \
-  etcdctl set 	/ft/healthcheck/$SERVICE-%i/categories 	read; \
+  etcdctl set 	/ft/healthcheck/$SERVICE-%i/categories 	read,enrichedcontent-read,content-read; \
   etcdctl set   /ft/services/$SERVICE/path-regex/public-services /content/.*; \
   etcdctl set   /ft/services/$SERVICE/path-host/public-services public-services; \
   while [ -z $PORT ]; do \

--- a/document-store-api-sidekick@.service
+++ b/document-store-api-sidekick@.service
@@ -10,7 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set   /ft/healthcheck/$SERVICE-%i/path /__health; \
-  etcdctl set   /ft/healthcheck/$SERVICE-%i/categories read,lists-read,lists-publish; \
+  etcdctl set   /ft/healthcheck/$SERVICE-%i/categories read,lists-read,lists-publish,enrichedcontent-read,content-read; \
   etcdctl set   /ft/services/$SERVICE/path-regex/public-services-lists /lists.*; \
   etcdctl set   /ft/services/$SERVICE/path-host/public-services-lists public-services; \
   while [ -z $PORT ]; do \
@@ -26,4 +26,3 @@ RestartSec=60
 
 [X-Fleet]
 MachineOf=document-store-api@%i.service
-

--- a/enriched-content-read-api-sidekick@.service
+++ b/enriched-content-read-api-sidekick@.service
@@ -10,7 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set   /ft/healthcheck/$SERVICE-%i/path /__health; \
-  etcdctl set   /ft/healthcheck/$SERVICE-%i/categories read; \
+  etcdctl set   /ft/healthcheck/$SERVICE-%i/categories read,enrichedcontent-read; \
   etcdctl set   /ft/services/$SERVICE/path-regex/public-services /enrichedcontent/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$; \
   etcdctl set   /ft/services/$SERVICE/path-host/public-services public-services; \
   while [ -z $PORT ]; do \

--- a/methode-article-transformer-sidekick@.service
+++ b/methode-article-transformer-sidekick@.service
@@ -10,6 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set 	/ft/healthcheck/$SERVICE-%i/categories content-read; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \

--- a/public-annotations-api-sidekick@.service
+++ b/public-annotations-api-sidekick@.service
@@ -10,6 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/categories enrichedcontent-read; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \

--- a/public-concordances-api-sidekick@.service
+++ b/public-concordances-api-sidekick@.service
@@ -10,7 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set   /ft/services/$SERVICE/healthcheck true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set   /ft/healthcheck/$SERVICE-%i/path /__health; \
-  etcdctl set   /ft/healthcheck/$SERVICE-%i/categories read,lists-publish; \
+  etcdctl set   /ft/healthcheck/$SERVICE-%i/categories read,lists-publish,concordances-read; \
   etcdctl set   /ft/services/$SERVICE/path-regex/public-services /concordances; \
   etcdctl set   /ft/services/$SERVICE/path-host/public-services public-services; \
   while [ -z $PORT ]; do \

--- a/system-healthcheck-sidekick.service
+++ b/system-healthcheck-sidekick.service
@@ -11,7 +11,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set /vulcand/frontends/system-healthcheck-%H/frontend \"{\\\"Type\\\":\\\"http\\\", \\\"BackendId\\\":\\\"system-healthcheck-%H\\\", \\\"Route\\\":\\\"Path(\`/health/system-healthcheck-%H/__health\`)\\\"}\"; \
   etcdctl set /vulcand/frontends/system-healthcheck-%H/middlewares/rewrite \"{\\\"Id\\\":\\\"rewrite\\\", \\\"Type\\\":\\\"rewrite\\\", \\\"Priority\\\":1, \\\"Middleware\\\": {\\\"Regexp\\\":\\\"/health/system-healthcheck-%H(.*)\\\", \\\"Replacement\\\":\\\"\$1\\\"}}\"; \
   etcdctl set /ft/healthcheck/system-healthcheck-%H/path /__health; \
-  etcdctl set /ft/healthcheck/system-healthcheck-%H/categories system,lists-read,lists-publish; \
+  etcdctl set /ft/healthcheck/system-healthcheck-%H/categories system,lists-read,lists-publish,concordances-read,enrichedcontent-read,content-read; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"_); \


### PR DESCRIPTION
Add categories for concordances, enrichedcontent and content-read flows, which will be used by the public endpoints' dashing tiles.

Tested in XP.

You could check the categories on:
{env-url}/__health?categories=content-read
{env-url}/__health?categories=enrichedcontent-read
{env-url}/__health?categories=concordances-read
