### PR TITLE
Upgrade to fleet unit healthcheck 1.0.8

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -150,7 +150,7 @@ services:
 - name: fleet-unit-healthcheck-sidekick@.service
   count: 1
 - name: fleet-unit-healthcheck@.service
-  version: 1.0.7
+  version: 1.0.8
   count: 1
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1


### PR DESCRIPTION
This release adds mongodb-online-backup to the timer service whitelist.