### PR TITLE
Remove public-read-preview from content endpoint read categories.

### DIFF
--- a/content-public-read-preview-sidekick@.service
+++ b/content-public-read-preview-sidekick@.service
@@ -10,7 +10,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set 	/ft/services/$SERVICE/healthcheck 		true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set 	/ft/healthcheck/$SERVICE-%i/path 		/__health; \
-  etcdctl set 	/ft/healthcheck/$SERVICE-%i/categories 	read,content-read; \
+  etcdctl set 	/ft/healthcheck/$SERVICE-%i/categories 	read; \
   etcdctl set   /ft/services/$SERVICE/path-regex/public-services /content-preview/.*; \
   etcdctl set   /ft/services/$SERVICE/path-host/public-services public-services; \
   while [ -z $PORT ]; do \

--- a/methode-article-transformer-sidekick@.service
+++ b/methode-article-transformer-sidekick@.service
@@ -10,7 +10,6 @@ ExecStart=/bin/sh -c "\
   etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
   etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
-  etcdctl set 	/ft/healthcheck/$SERVICE-%i/categories content-read; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \


### PR DESCRIPTION
ETCD keys for methode-article-transformer will need to be manually deleted.

Tested in XP.