### PR TITLE
introducing kafka-lagcheck

### DIFF
--- a/burrow-sidekick@.service
+++ b/burrow-sidekick@.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Burrow Sidekick
+BindsTo=burrow@%i.service
+After=burrow@%i.service
+
+[Service]
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "\
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl set /ft/services/$SERVICE/healthcheck false; \
+  etcdctl mkdir /ft/services/burrow/servers; \
+  while [ -z $BURROW_PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+    BURROW_PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/burrow/servers/%i http://%H:$BURROW_PORT;"
+
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/burrow/servers/%i
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=burrow@%i.service

--- a/burrow-sidekick@.service
+++ b/burrow-sidekick@.service
@@ -16,7 +16,7 @@ ExecStart=/bin/sh -c "\
   done; \
   etcdctl set /ft/services/burrow/servers/%i http://%H:$PORT;"
 
-ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/burrow/servers/%i
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/burrow/servers/%i'
 Restart=on-failure
 RestartSec=60
 

--- a/burrow-sidekick@.service
+++ b/burrow-sidekick@.service
@@ -9,12 +9,12 @@ ExecStart=/bin/sh -c "\
   export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
   etcdctl set /ft/services/$SERVICE/healthcheck false; \
   etcdctl mkdir /ft/services/burrow/servers; \
-  while [ -z $BURROW_PORT ]; do \
+  while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
-    BURROW_PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
   done; \
-  etcdctl set /ft/services/burrow/servers/%i http://%H:$BURROW_PORT;"
+  etcdctl set /ft/services/burrow/servers/%i http://%H:$PORT;"
 
 ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/burrow/servers/%i
 Restart=on-failure

--- a/burrow@.service
+++ b/burrow@.service
@@ -19,7 +19,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
-  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \
     --env "ZOOKEEPER_HOST=$ZOOKEEPER_HOST" \
     --env "ZOOKEEPER_PORT=$ZOOKEEPER_PORT" \
     --env "KAFKA_HOST=$KAFKA_HOST" \

--- a/burrow@.service
+++ b/burrow@.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=burrow service
+After=vulcan.service
+Requires=docker.service
+Wants=burrow-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/burrow:$DOCKER_APP_VERSION > /dev/null 2>&1 \
+  || /usr/bin/docker pull coco/burrow:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/sh -c '\
+  export ZOOKEEPER_HOST=$(/usr/bin/etcdctl get /ft/config/zookeeper/ip); \
+  export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
+  export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
+  export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
+    --env "ZOOKEEPER_HOST=$ZOOKEEPER_HOST" \
+    --env "ZOOKEEPER_PORT=$ZOOKEEPER_PORT" \
+    --env "KAFKA_HOST=$KAFKA_HOST" \
+    --env "KAFKA_PORT=$KAFKA_PORT" \
+    coco/burrow:$DOCKER_APP_VERSION;'
+
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=burrow@*.service

--- a/burrow@.service
+++ b/burrow@.service
@@ -20,6 +20,7 @@ ExecStart=/bin/sh -c '\
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \
+    --memory="256m" \
     --env "ZOOKEEPER_HOST=$ZOOKEEPER_HOST" \
     --env "ZOOKEEPER_PORT=$ZOOKEEPER_PORT" \
     --env "KAFKA_HOST=$KAFKA_HOST" \

--- a/kafka-lagcheck-sidekick@.service
+++ b/kafka-lagcheck-sidekick@.service
@@ -15,7 +15,7 @@ ExecStart=/bin/sh -c "\
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
     KAFKA_LAGCHECK_PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
   done; \
-  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$KAFKA_LAGCHECK_PORT; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$KAFKA_LAGCHECK_PORT;"
 
 ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/kafka-lagcheck/servers/%i \
   /usr/bin/etcdctl rm /ft/services/burrow/servers/%i'

--- a/kafka-lagcheck-sidekick@.service
+++ b/kafka-lagcheck-sidekick@.service
@@ -17,7 +17,7 @@ ExecStart=/bin/sh -c "\
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
-ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/kafka-lagcheck/servers/%i
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/kafka-lagcheck/servers/%i'
 Restart=on-failure
 RestartSec=60
 

--- a/kafka-lagcheck-sidekick@.service
+++ b/kafka-lagcheck-sidekick@.service
@@ -10,15 +10,14 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/services/$SERVICE/healthcheck true; \
   etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
-  while [ -z $KAFKA_LAGCHECK_PORT ]; do \
+  while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
-    KAFKA_LAGCHECK_PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
   done; \
-  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$KAFKA_LAGCHECK_PORT;"
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
-ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/kafka-lagcheck/servers/%i \
-  /usr/bin/etcdctl rm /ft/services/burrow/servers/%i'
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/kafka-lagcheck/servers/%i
 Restart=on-failure
 RestartSec=60
 

--- a/kafka-lagcheck-sidekick@.service
+++ b/kafka-lagcheck-sidekick@.service
@@ -16,13 +16,6 @@ ExecStart=/bin/sh -c "\
     KAFKA_LAGCHECK_PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$KAFKA_LAGCHECK_PORT; \
-  etcdctl mkdir /ft/services/burrow/servers; \
-  while [ -z $BURROW_PORT ]; do \
-    sleep 5; \
-    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
-    BURROW_PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8081 | cut -d':' -f2)`; \
-  done; \
-  etcdctl set /ft/services/burrow/servers/%i http://%H:$BURROW_PORT;"
 
 ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/kafka-lagcheck/servers/%i \
   /usr/bin/etcdctl rm /ft/services/burrow/servers/%i'

--- a/kafka-lagcheck-sidekick@.service
+++ b/kafka-lagcheck-sidekick@.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Kafka Lagcheck Sidekick
+BindsTo=kafka-lagcheck@%i.service
+After=kafka-lagcheck@%i.service
+
+[Service]
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "\
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl set /ft/services/$SERVICE/healthcheck true; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  while [ -z $KAFKA_LAGCHECK_PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+    KAFKA_LAGCHECK_PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$KAFKA_LAGCHECK_PORT; \
+  etcdctl mkdir /ft/services/burrow/servers; \
+  while [ -z $BURROW_PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+    BURROW_PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8081 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/burrow/servers/%i http://%H:$BURROW_PORT;"
+
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/kafka-lagcheck/servers/%i \
+  /usr/bin/etcdctl rm /ft/services/burrow/servers/%i'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=kafka-lagcheck@%i.service

--- a/kafka-lagcheck@.service
+++ b/kafka-lagcheck@.service
@@ -16,6 +16,7 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/kafka-lagcheck:$DOCKER_A
   
 ExecStart=/bin/sh -c '\
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \
+    --memory="256m" \
     --env "HOST_MACHINE=%H" \
     --env "WHITELISTED_TOPICS=Concept" \
     --env "LAG_TOLERANCE=30" \

--- a/kafka-lagcheck@.service
+++ b/kafka-lagcheck@.service
@@ -15,8 +15,8 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/kafka-lagcheck:$DOCKER_A
   || /usr/bin/docker pull coco/kafka-lagcheck:$DOCKER_APP_VERSION'
   
 ExecStart=/bin/sh -c '\
+  LAG_TOLERANCE=$(etcdctl get /ft/config/kafka-lagcheck/lag-tolerance) || LAG_TOLERANCE=30; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \
-    LAG_TOLERANCE=$(etcdctl get /ft/config/kafka-lagcheck/lag-tolerance) || LAG_TOLERANCE=30; \
     --memory="256m" \
     --env "HOST_MACHINE=%H" \
     --env "WHITELISTED_TOPICS=Concept" \

--- a/kafka-lagcheck@.service
+++ b/kafka-lagcheck@.service
@@ -16,10 +16,11 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/kafka-lagcheck:$DOCKER_A
   
 ExecStart=/bin/sh -c '\
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \
+    LAG_TOLERANCE=$(etcdctl get /ft/config/kafka-lagcheck/lag-tolerance) || LAG_TOLERANCE=30; \
     --memory="256m" \
     --env "HOST_MACHINE=%H" \
     --env "WHITELISTED_TOPICS=Concept" \
-    --env "LAG_TOLERANCE=30" \
+    --env "LAG_TOLERANCE=$LAG_TOLERANCE" \
     coco/kafka-lagcheck:$DOCKER_APP_VERSION;'
     
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/kafka-lagcheck@.service
+++ b/kafka-lagcheck@.service
@@ -24,7 +24,8 @@ ExecStart=/bin/sh -c '\
     --env "ZOOKEEPER_PORT=$ZOOKEEPER_PORT" \
     --env "KAFKA_HOST=$KAFKA_HOST" \
     --env "KAFKA_PORT=$KAFKA_PORT" \
-    --env "CONSUMER_GROUPS=contentIngester" \
+    --env "WHITELISTED_TOPICS=Concept" \
+    --env "LAG_TOLERANCE=30" \
     coco/kafka-lagcheck:$DOCKER_APP_VERSION;'
     
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/kafka-lagcheck@.service
+++ b/kafka-lagcheck@.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=kafka lagcheck service
+After=vulcan.service
+Requires=docker.service
+Wants=kafka-lagcheck-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/kafka-lagcheck:$DOCKER_APP_VERSION > /dev/null 2>&1 \
+  || /usr/bin/docker pull coco/kafka-lagcheck:$DOCKER_APP_VERSION'
+  
+ExecStart=/bin/sh -c '\
+  export ZOOKEEPER_HOST=$(/usr/bin/etcdctl get /ft/config/zookeeper/ip); \
+  export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
+  export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
+  export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
+    --env "ZOOKEEPER_HOST=$ZOOKEEPER_HOST" \
+    --env "ZOOKEEPER_PORT=$ZOOKEEPER_PORT" \
+    --env "KAFKA_HOST=$KAFKA_HOST" \
+    --env "KAFKA_PORT=$KAFKA_PORT" \
+    --env "CONSUMER_GROUPS=contentIngester" \
+    coco/kafka-lagcheck:$DOCKER_APP_VERSION;'
+    
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=kafka-lagcheck@*.service

--- a/kafka-lagcheck@.service
+++ b/kafka-lagcheck@.service
@@ -15,15 +15,8 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/kafka-lagcheck:$DOCKER_A
   || /usr/bin/docker pull coco/kafka-lagcheck:$DOCKER_APP_VERSION'
   
 ExecStart=/bin/sh -c '\
-  export ZOOKEEPER_HOST=$(/usr/bin/etcdctl get /ft/config/zookeeper/ip); \
-  export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
-  export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
-  export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
-  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
-    --env "ZOOKEEPER_HOST=$ZOOKEEPER_HOST" \
-    --env "ZOOKEEPER_PORT=$ZOOKEEPER_PORT" \
-    --env "KAFKA_HOST=$KAFKA_HOST" \
-    --env "KAFKA_PORT=$KAFKA_PORT" \
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \
+    --env "HOST_MACHINE=%H" \
     --env "WHITELISTED_TOPICS=Concept" \
     --env "LAG_TOLERANCE=30" \
     coco/kafka-lagcheck:$DOCKER_APP_VERSION;'

--- a/services.yaml
+++ b/services.yaml
@@ -180,7 +180,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: v0.0.11
+  version: v1.0.0
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -42,6 +42,11 @@ services:
   version: v0.1.3
   count: 1
   sequentialDeployment: true
+- name: burrow-sidekick@.service
+  count: 1
+- name: burrow@.service
+  version: v1.0.1
+  count: 1
 - name: cms-kafka-bridge-pub-prod-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod@.service

--- a/services.yaml
+++ b/services.yaml
@@ -180,7 +180,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: v1.0.1
+  version: v1.0.2
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -185,7 +185,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: v1.0.5
+  version: v1.0.6
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -182,6 +182,11 @@ services:
 - name: industry-classifications-rw-neo4j-red@.service
   version: v0.0.6
   count: 1
+- name: kafka-lagcheck-sidekick@.service
+  count: 1
+- name: kafka-lagcheck@.service
+  version: v1.0.4
+  count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1
 - name: kafka-rest-proxy@.service

--- a/services.yaml
+++ b/services.yaml
@@ -177,6 +177,11 @@ services:
 - name: industry-classifications-rw-neo4j-red@.service
   version: v0.0.5
   count: 1
+- name: kafka-lagcheck-sidekick@.service
+  count: 1
+- name: kafka-lagcheck@.service
+  version: v0.0.11
+  count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1
 - name: kafka-rest-proxy@.service

--- a/services.yaml
+++ b/services.yaml
@@ -180,7 +180,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: v1.0.2
+  version: v1.0.3
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -182,11 +182,6 @@ services:
 - name: industry-classifications-rw-neo4j-red@.service
   version: v0.0.6
   count: 1
-- name: kafka-lagcheck-sidekick@.service
-  count: 1
-- name: kafka-lagcheck@.service
-  version: v1.0.3
-  count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1
 - name: kafka-rest-proxy@.service

--- a/services.yaml
+++ b/services.yaml
@@ -180,7 +180,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: v1.0.0
+  version: v1.0.1
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -185,7 +185,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: v1.0.4
+  version: v1.0.5
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1


### PR DESCRIPTION
https://github.com/Financial-Times/kafka-lagcheck
https://github.com/Financial-Times/burrow
https://github.com/Financial-Times/pub-service-files/pull/55

* Allowed lag is set to 30 currently.
* Concept is an ignored partition.
* Burrow can show partitions in unhealthy state even if lag is less than 30, if it is seeing the stalled or stopped. (https://github.com/linkedin/Burrow/wiki/Consumer-Lag-Evaluation-Rules) These are special cases, we'll need to see this lagcheck running in live, and see its behaviour during a mass publish.
* Can be acked any time.
* Memory limit on both apps: 256MB
* Present in xp, pub-xp, pub-pre-prod-uk, pre-prod-uk