### PR TITLE
Upgrade to Go apps using Neo4j

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -8,12 +8,12 @@ services:
 - name: alphaville-series-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: alphaville-series-rw-neo4j-blue@.service
-  version: v0.0.6
+  version: v0.0.8
   count: 1
 - name: alphaville-series-rw-neo4j-red-sidekick@.service
   count: 1
 - name: alphaville-series-rw-neo4j-red@.service
-  version: v0.0.6
+  version: v0.0.8
   count: 1
 - name: api-policy-component-sidekick@.service
   count: 2
@@ -34,12 +34,12 @@ services:
 - name: brands-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: brands-rw-neo4j-blue@.service
-  version: v0.1.2
+  version: v0.1.3
   count: 1
 - name: brands-rw-neo4j-red-sidekick@.service
   count: 1
 - name: brands-rw-neo4j-red@.service
-  version: v0.1.2
+  version: v0.1.3
   count: 1
   sequentialDeployment: true
 - name: cms-kafka-bridge-pub-prod-sidekick@.service
@@ -123,12 +123,12 @@ services:
 - name: content-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: content-rw-neo4j-blue@.service
-  version: v0.0.34
+  version: v0.0.36
   count: 1
 - name: content-rw-neo4j-red-sidekick@.service
   count: 1
 - name: content-rw-neo4j-red@.service
-  version: v0.0.34
+  version: v0.0.36
   count: 1
 - name: coreos-version-checker-sidekick.service
 - name: coreos-version-checker.service
@@ -158,24 +158,24 @@ services:
 - name: genres-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-blue@.service
-  version: v1.1.4
+  version: v1.1.5
   count: 1
 - name: genres-rw-neo4j-red-sidekick@.service
   count: 1
 - name: genres-rw-neo4j-red@.service
-  version: v1.1.4
+  version: v1.1.5
   count: 1
 - name: image-cleaner.service
   version: 1.0.0
 - name: industry-classifications-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: industry-classifications-rw-neo4j-blue@.service
-  version: v0.0.5
+  version: v0.0.6
   count: 1
 - name: industry-classifications-rw-neo4j-red-sidekick@.service
   count: 1
 - name: industry-classifications-rw-neo4j-red@.service
-  version: v0.0.5
+  version: v0.0.6
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1
@@ -186,22 +186,22 @@ services:
 - name: locations-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: locations-rw-neo4j-blue@.service
-  version: v1.1.2
+  version: v1.1.3
   count: 1
 - name: locations-rw-neo4j-red-sidekick@.service
   count: 1
 - name: locations-rw-neo4j-red@.service
-  version: v1.1.2
+  version: v1.1.3
   count: 1
 - name: memberships-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: memberships-rw-neo4j-blue@.service
-  version: v0.1.3
+  version: v0.1.4
   count: 1
 - name: memberships-rw-neo4j-red-sidekick@.service
   count: 1
 - name: memberships-rw-neo4j-red@.service
-  version: v0.1.3
+  version: v0.1.4
   count: 1
 - name: methode-article-transformer-sidekick@.service
   count: 2
@@ -286,24 +286,24 @@ services:
 - name: organisations-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: organisations-rw-neo4j-blue@.service
-  version: v0.3.0
+  version: v0.3.1
   count: 1
 - name: organisations-rw-neo4j-red-sidekick@.service
   count: 1
 - name: organisations-rw-neo4j-red@.service
-  version: v0.3.0
+  version: v0.3.1
   count: 1
 - name: os-upgrade.service
   desiredState: loaded
 - name: people-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: people-rw-neo4j-blue@.service
-  version: v0.1.2
+  version: v0.1.3
   count: 1
 - name: people-rw-neo4j-red-sidekick@.service
   count: 1
 - name: people-rw-neo4j-red@.service
-  version: v0.1.2
+  version: v0.1.3
   count: 1
 - name: public-annotations-api-sidekick@.service
   count: 2
@@ -365,43 +365,43 @@ services:
 - name: roles-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: roles-rw-neo4j-blue@.service
-  version: v0.1.3
+  version: v0.1.4
   count: 1
 - name: roles-rw-neo4j-red-sidekick@.service
   count: 1
 - name: roles-rw-neo4j-red@.service
-  version: v0.1.3
+  version: v0.1.4
   count: 1
 - name: sections-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: sections-rw-neo4j-blue@.service
-  version: v1.1.2
+  version: v1.1.3
   count: 1
 - name: sections-rw-neo4j-red-sidekick@.service
   count: 1
 - name: sections-rw-neo4j-red@.service
-  version: v1.1.2
+  version: v1.1.3
   count: 1
 - name: special-reports-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: special-reports-rw-neo4j-blue@.service
-  version: v1.1.2
+  version: v1.1.3
   count: 1
 - name: special-reports-rw-neo4j-red-sidekick@.service
   count: 1
 - name: special-reports-rw-neo4j-red@.service
-  version: v1.1.2
+  version: v1.1.3
   count: 1
 - name: splunk-forwarder.service
 - name: subjects-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: subjects-rw-neo4j-blue@.service
-  version: v1.1.1
+  version: v1.1.2
   count: 1
 - name: subjects-rw-neo4j-red-sidekick@.service
   count: 1
 - name: subjects-rw-neo4j-red@.service
-  version: v1.1.1
+  version: v1.1.2
   count: 1
 - name: synthetic-image-publication-monitor-aws-sidekick@.service
   count: 1
@@ -419,12 +419,12 @@ services:
 - name: topics-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: topics-rw-neo4j-blue@.service
-  version: v1.1.2
+  version: v1.1.3
   count: 1
 - name: topics-rw-neo4j-red-sidekick@.service
   count: 1
 - name: topics-rw-neo4j-red@.service
-  version: v1.1.2
+  version: v1.1.3
   count: 1
 - name: tunnel-registrator.service
   version: 1.0.0


### PR DESCRIPTION
Reconnect is enabled
Exe has been renamed to repo name.

Also, here are probably all the pull requests going into this release:
Financial-Times/content-rw-neo4j#10
Financial-Times/financial-instruments-rw-neo4j#3
Financial-Times/industry-classifications-rw-neo4j#8
Financial-Times/topics-rw-neo4j#4
Financial-Times/alphaville-series-rw-neo4j#8
Financial-Times/genres-rw-neo4j#6
Financial-Times/subjects-rw-neo4j#5
Financial-Times/special-reports-rw-neo4j#4
Financial-Times/sections-rw-neo4j#5
Financial-Times/roles-rw-neo4j#7
Financial-Times/organisations-rw-neo4j#17
Financial-Times/memberships-rw-neo4j#7
Financial-Times/locations-rw-neo4j#4
Financial-Times/content-rw-neo4j#9
Financial-Times/brands-rw-neo4j#8
Financial-Times/neo-utils-go#18
Financial-Times/neo-utils-go#17
Financial-Times/neo-utils-go#16
Financial-Times/neo-utils-go#15
Financial-Times/neo-utils-go#14