### PR TITLE
Updated Neo4J to 2.3.7 - BLUE ONLY

### DIFF
--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -18,11 +18,11 @@ ExecStartPre=/bin/bash -c 'docker history coco/ft-neo4j:$DOCKER_APP_VERSION > /d
 # Also see https://neo4j.com/developer/docker-2-x/ for configuration options.
 ExecStart=/bin/sh -c "\
     /usr/bin/docker run --rm --name %p-%i_$(uuidgen) \
-    --memory="4g" \
+    --memory="5g" \
     -v /vol/%p-%i/:/data -p 7474:7474 \
     --env=NEO4J_AUTH=none \
-    --env=NEO4J_HEAP_MEMORY=2048 \
-    --env=NEO4J_CACHE_MEMORY=2048m \
+    --env=NEO4J_HEAP_MEMORY=4096 \
+    --env=NEO4J_CACHE_MEMORY=1024 \
     coco/ft-neo4j:$DOCKER_APP_VERSION"
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'

--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -21,8 +21,8 @@ ExecStart=/bin/sh -c "\
     --memory="5g" \
     -v /vol/%p-%i/:/data -p 7474:7474 \
     --env=NEO4J_AUTH=none \
-    --env=NEO4J_HEAP_MEMORY=4096 \
-    --env=NEO4J_CACHE_MEMORY=1024 \
+    --env=NEO4J_HEAP_MEMORY=4096m \
+    --env=NEO4J_CACHE_MEMORY=1024m \
     coco/ft-neo4j:$DOCKER_APP_VERSION"
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'

--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -21,7 +21,7 @@ ExecStart=/bin/sh -c "\
     --memory="5g" \
     -v /vol/%p-%i/:/data -p 7474:7474 \
     --env=NEO4J_AUTH=none \
-    --env=NEO4J_HEAP_MEMORY=4096m \
+    --env=NEO4J_HEAP_MEMORY=3584 \
     --env=NEO4J_CACHE_MEMORY=1024m \
     coco/ft-neo4j:$DOCKER_APP_VERSION"
 

--- a/services.yaml
+++ b/services.yaml
@@ -255,7 +255,7 @@ services:
 - name: neo4j-blue-sidekick@.service
   count: 1
 - name: neo4j-blue@.service
-  version: 2.3.1-3
+  version: 2.3.7-1
   count: 1
 - name: neo4j-read-blue-sidekick@.service
   count: 1


### PR DESCRIPTION
Updating the blue Neo4J to 2.3.7. We have split them into two PR's so that we don't need to do a ZDD