### PR TITLE
Use a fixed version of mongodb-configurator

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -235,6 +235,7 @@ services:
 - name: mongo-backup@.timer
   count: 3
 - name: mongodb-configurator.service
+  version: v0.1.0
 - name: mongodb-online-backup.service
   version: v0.1.0
   desiredState: loaded


### PR DESCRIPTION
Set version to newly released v0.1.0, which has no changes from the
current "latest" version in use.