### PR TITLE
Added load-replicator 1.0.0

### DIFF
--- a/load-replicator-sidekick@.service
+++ b/load-replicator-sidekick@.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Load Replicator Sidekick
+BindsTo=load-replicator@%i.service
+After=load-replicator@%i.service
+
+[Service]
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "\
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  while [ -z $PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=^/\"$SERVICE\"-%i_); \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
+
+ExecStop=-/bin/bash -c 'etcdctl rm /ft/services/load-replicator/servers/%i'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=load-replicator@%i.service

--- a/load-replicator@.service
+++ b/load-replicator@.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Load Replicator
+After=vulcan.service
+Requires=docker.service
+Wants=load-replicator-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker history coco/load-replicator:$DOCKER_APP_VERSION > /dev/null 2>&1 || docker pull coco/load-replicator:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/sh -c '\
+  ENDPOINT_RATE_PAIRS=$(/usr/bin/etcdctl get /ft/config/load-replicator/endpoint-rate-pairs) || ENDPOINT_RATE_PAIRS="things:1;enrichedcontent:3"; \
+  AUTHORIZATION=$(/usr/bin/etcdctl get /ft/config/load-replicator/authorization); \
+  ENVIRONMENT=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
+  DURATION=$(/usr/bin/etcdctl get /ft/config/load-replicator/duration) || DURATION=0; \
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \
+  --env "ENDPOINT_RATE_PAIRS=$ENDPOINT_RATE_PAIRS" \
+  --env "AUTHORIZATION=$AUTHORIZATION" \
+  --env "ENVIRONMENT=$ENVIRONMENT" \
+  --env "DURATION=$DURATION" \
+  coco/load-replicator:$DOCKER_APP_VERSION'
+
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=%p@*.service

--- a/services.yaml
+++ b/services.yaml
@@ -210,6 +210,11 @@ services:
   version: v1.0.0
   count: 1
 - name: kafka.service
+- name: load-replicator@.service
+  version: v1.0.0
+  count: 1
+- name: load-replicator-sidekick@.service
+  count: 1
 - name: locations-rw-neo4j-blue-sidekick@.service
   count: 1
 - name: locations-rw-neo4j-blue@.service


### PR DESCRIPTION
Added initial version of the load-replicator that tries to replicate the production load in a lower environment (pre-prod in this case).

https://github.com/Financial-Times/load-replicator

read load in xp: http://grafana.ft.com/dashboard/db/coco-api-policy-component-response-metrics?from=now-24h&to=now&var-environment=xp&var-node=All
read load in prod-uk: http://grafana.ft.com/dashboard/db/coco-api-policy-component-response-metrics?from=now-24h&to=now&var-environment=prod-uk&var-node=All