### PR TITLE
Reducing DSAPI Logging

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -132,7 +132,7 @@ services:
 - name: document-store-api-sidekick@.service
   count: 2
 - name: document-store-api@.service
-  version: v82
+  version: v83
   count: 2
   sequentialDeployment: true
 - name: elb-dns-registrator.service


### PR DESCRIPTION
Currently, 404s produce huge amounts of logging due to an unnecessary stacktrace; this is now suppressed (now at DEBUG level).