### PR TITLE
Allow vulcan to recognise the new user-agent

### DIFF
--- a/neo4j-read-blue-sidekick@.service
+++ b/neo4j-read-blue-sidekick@.service
@@ -9,7 +9,7 @@ ExecStart=/bin/sh -c '\
    etcdctl set /vulcand/backends/neo4j-read/backend \'{\"Type\": \"http\", \"Settings\": {\"KeepAlive\": {\"MaxIdleConnsPerHost\": 256, \"Period\": \"35s\"}}}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
-   etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
+   etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && HeaderRegexp(`User-Agent`, `neoism|.*neoutils.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
    while [ -z $PORT ]; do \
      sleep 5; \
      CONTAINER_NAME=$(docker ps -q --filter=name=^/neo4j-blue-%i_); \

--- a/neo4j-read-blue-sidekick@.service
+++ b/neo4j-read-blue-sidekick@.service
@@ -9,7 +9,7 @@ ExecStart=/bin/sh -c '\
    etcdctl set /vulcand/backends/neo4j-read/backend \'{\"Type\": \"http\", \"Settings\": {\"KeepAlive\": {\"MaxIdleConnsPerHost\": 256, \"Period\": \"35s\"}}}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
-   etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
+   etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && HeaderRegexp(`User-Agent`, `neoism|.*neoutils.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
    while [ -z $PORT ]; do \
      sleep 5; \
      CONTAINER_NAME=$(docker ps -q --filter=name=^/neo4j-blue-%i_); \

--- a/neo4j-read-blue-sidekick@.service
+++ b/neo4j-read-blue-sidekick@.service
@@ -9,7 +9,7 @@ ExecStart=/bin/sh -c '\
    etcdctl set /vulcand/backends/neo4j-read/backend \'{\"Type\": \"http\", \"Settings\": {\"KeepAlive\": {\"MaxIdleConnsPerHost\": 256, \"Period\": \"35s\"}}}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
    etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
-   etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && HeaderRegexp(`User-Agent`, `neoism|.*neoutils.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
+   etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
    while [ -z $PORT ]; do \
      sleep 5; \
      CONTAINER_NAME=$(docker ps -q --filter=name=^/neo4j-blue-%i_); \

--- a/neo4j-read-red-sidekick@.service
+++ b/neo4j-read-red-sidekick@.service
@@ -9,7 +9,7 @@ ExecStart=/bin/sh -c '\
   etcdctl set /vulcand/backends/neo4j-read/backend \'{\"Type\": \"http\", \"Settings\": {\"KeepAlive\": {\"MaxIdleConnsPerHost\": 256, \"Period\": \"35s\"}}}\'; \
   etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
   etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
-  etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
+  etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && HeaderRegexp(`User-Agent`, `neoism|.*neoutils.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=^/neo4j-red-%i_); \

--- a/neo4j-read-red-sidekick@.service
+++ b/neo4j-read-red-sidekick@.service
@@ -9,7 +9,7 @@ ExecStart=/bin/sh -c '\
   etcdctl set /vulcand/backends/neo4j-read/backend \'{\"Type\": \"http\", \"Settings\": {\"KeepAlive\": {\"MaxIdleConnsPerHost\": 256, \"Period\": \"35s\"}}}\'; \
   etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
   etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
-  etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism|.*neoutils.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
+  etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=^/neo4j-red-%i_); \

--- a/neo4j-read-red-sidekick@.service
+++ b/neo4j-read-red-sidekick@.service
@@ -9,7 +9,7 @@ ExecStart=/bin/sh -c '\
   etcdctl set /vulcand/backends/neo4j-read/backend \'{\"Type\": \"http\", \"Settings\": {\"KeepAlive\": {\"MaxIdleConnsPerHost\": 256, \"Period\": \"35s\"}}}\'; \
   etcdctl set /vulcand/frontends/neo4j-read/frontend \'{"Type": "http", "BackendId\": "neo4j-read", "Route": "PathRegexp(`/__neo4j-read/.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
   etcdctl set /vulcand/frontends/neo4j-read/middlewares/rewrite \'{"Id":"rewrite", "Type":"rewrite", "Priority":1, "Middleware": {"Regexp":"/__neo4j-read(/.*)", "Replacement":"$1"}}\'; \
-  etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
+  etcdctl set /vulcand/frontends/neo4j-read-db/frontend \'{"Type": "http", "BackendId": "neo4j-read", "Route": "PathRegexp(`^/db/data/.*`) && Header(`User-Agent`, `neoism|.*neoutils.*`)", "Settings": { "TrustForwardHeader": true, "PassHostHeader": true }}\'; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=^/neo4j-red-%i_); \

--- a/services.yaml
+++ b/services.yaml
@@ -340,7 +340,7 @@ services:
 - name: public-people-api-sidekick@.service
   count: 2
 - name: public-people-api@.service
-  version: v0.1.3
+  version: notrans-1
   count: 2
   sequentialDeployment: true
 - name: public-six-degrees-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -340,7 +340,7 @@ services:
 - name: public-people-api-sidekick@.service
   count: 2
 - name: public-people-api@.service
-  version: notrans-1
+  version: v0.1.3
   count: 2
   sequentialDeployment: true
 - name: public-six-degrees-sidekick@.service


### PR DESCRIPTION
Since the user agent was changed in neoutils to describe the exe making the call (eg. "**public-people-api (using neoutils)**"),  the vulcan rewrite rule for public reads hasn't been working correctly on connection.