### PR TITLE
Migrating BitBucket varnish to Github

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -506,7 +506,7 @@ services:
   version: v24
   count: 1
 - name: varnish@.service
-  version: v75
+  version: v0.0.4
   count: 2
   sequentialDeployment: true
 - name: video-mapper-sidekick@.service

--- a/varnish@.service
+++ b/varnish@.service
@@ -12,8 +12,8 @@ TimeoutStartSec=0
 KillMode=none
 ExecStartPre=-/bin/bash -c 'docker kill "$(docker ps -q --filter=name=%p-%i_)" >/dev/null 2>&1'
 ExecStartPre=-/bin/bash -c 'docker rm "$(docker ps -q --filter=name=%p-%i_)" >/dev/null 2>&1'
-ExecStartPre=/bin/bash -c 'docker history up-registry.ft.com/coco/varnish:$DOCKER_APP_VERSION >/dev/null 2>&1 \
-  || docker pull up-registry.ft.com/coco/varnish:$DOCKER_APP_VERSION'
+ExecStartPre=/bin/bash -c 'docker history up-registry.ft.com/coco/delivery-varnish:$DOCKER_APP_VERSION >/dev/null 2>&1 \
+  || docker pull up-registry.ft.com/coco/delivery-varnish:$DOCKER_APP_VERSION'
 
 ExecStart=/bin/bash -c '\
   ETCD_HOST="http://%H:2379"; \
@@ -25,7 +25,7 @@ ExecStart=/bin/bash -c '\
   -e "HOST_HEADER=api-policy-component" \
   -e "ETCD_HOST=$ETCD_HOST" \
   -e "ETCD_CONFIG_KEY=$ETCD_CONFIG_KEY" \
-  up-registry.ft.com/coco/varnish:$DOCKER_APP_VERSION'
+  up-registry.ft.com/coco/delivery-varnish:$DOCKER_APP_VERSION'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
 

--- a/varnish@.service
+++ b/varnish@.service
@@ -12,8 +12,8 @@ TimeoutStartSec=0
 KillMode=none
 ExecStartPre=-/bin/bash -c 'docker kill "$(docker ps -q --filter=name=%p-%i_)" >/dev/null 2>&1'
 ExecStartPre=-/bin/bash -c 'docker rm "$(docker ps -q --filter=name=%p-%i_)" >/dev/null 2>&1'
-ExecStartPre=/bin/bash -c 'docker history up-registry.ft.com/coco/delivery-varnish:$DOCKER_APP_VERSION >/dev/null 2>&1 \
-  || docker pull up-registry.ft.com/coco/delivery-varnish:$DOCKER_APP_VERSION'
+ExecStartPre=/bin/bash -c 'docker history coco/delivery-varnish:$DOCKER_APP_VERSION >/dev/null 2>&1 \
+  || docker pull coco/delivery-varnish:$DOCKER_APP_VERSION'
 
 ExecStart=/bin/bash -c '\
   ETCD_HOST="http://%H:2379"; \
@@ -25,7 +25,7 @@ ExecStart=/bin/bash -c '\
   -e "HOST_HEADER=api-policy-component" \
   -e "ETCD_HOST=$ETCD_HOST" \
   -e "ETCD_CONFIG_KEY=$ETCD_CONFIG_KEY" \
-  up-registry.ft.com/coco/delivery-varnish:$DOCKER_APP_VERSION'
+  coco/delivery-varnish:$DOCKER_APP_VERSION'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
 


### PR DESCRIPTION
Please also review the new repo [here](https://github.com/Financial-Times/delivery-varnish) for delivery varnish - it should be functionally the same as the [bitbucket](http://git.svc.ft.com/projects/CP/repos/api-component-policy-varnish/browse) version.