### PR TITLE
Updating DNS service versions to update TTLs to 30s

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -136,7 +136,7 @@ services:
   count: 2
   sequentialDeployment: true
 - name: elb-dns-registrator.service
-  version: v4.0.0
+  version: v4.0.1
 - name: elb-presence@.service
   count: 2
 - name: enriched-content-read-api-sidekick@.service
@@ -434,7 +434,7 @@ services:
   version: v1.1.3
   count: 1
 - name: tunnel-registrator.service
-  version: 1.0.0
+  version: v1.0.1
 - name: up-queue-sender-v1-metadata-sidekick@.service
   count: 1
 - name: up-queue-sender-v1-metadata@.service


### PR DESCRIPTION
Bumping elb-dns-registrator to v4.0.1 and tunnel-registrator to v1.0.1 to update DNS TTL values to 30s.
