### PR TITLE
splunk-forwarder: Switch to Splunk HTTP Event Collector

### DIFF
--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -20,7 +20,7 @@ ExecStartPre=/bin/bash -c 'docker history coco/coco-logfilter:$DOCKER_LOGFILTER_
 ExecStart=/bin/sh -c '\
   export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_url); \
   export TOKEN=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_token); \
-  export BATCHSIZE=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/batchsize) || export BATCHSIZE=10; \
+  BATCHSIZE=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/batchsize) || BATCHSIZE=10; \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
   journalctl -a -f --since=now --output=json \
   | docker run -i --log-driver=none -e=ENV=$ENV --rm --name %p-filter_$(uuidgen) --memory="256m" coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION \

--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -3,7 +3,7 @@ Description=Splunk forwarder
 
 [Service]
 
-Environment="DOCKER_FORWARDER_VERSION=v1.0.0"
+Environment="DOCKER_FORWARDER_VERSION=v1.0.1"
 Environment="DOCKER_LOGFILTER_VERSION=v1.0.4"
 TimeoutStartSec=1200
 # Change killmode from "control-group" to "none" to let Docker remove
@@ -20,10 +20,11 @@ ExecStartPre=/bin/bash -c 'docker history coco/coco-logfilter:$DOCKER_LOGFILTER_
 ExecStart=/bin/sh -c '\
   export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_url); \
   export TOKEN=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_token); \
+  export BATCHSIZE=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/batchsize) || export BATCHSIZE=10; \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
   journalctl -a -f --since=now --output=json \
   | docker run -i --log-driver=none -e=ENV=$ENV --rm --name %p-filter_$(uuidgen) --memory="256m" coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION \
-  | docker run -i --log-driver=none --rm --name %p-http_$(uuidgen) --memory="256m" -e="FORWARD_URL=$FORWARD_URL" -e="ENV=$ENV" -e="HOSTNAME=$(hostname -s)" -e="WORKERS=8" -e="BUFFER=256" -e="TOKEN=$TOKEN" -e="BATCHSIZE=10" -e="BATCHTIMER=5" coco/coco-splunk-http-forwarder:$DOCKER_FORWARDER_VERSION'
+  | docker run -i --log-driver=none --rm --name %p-http_$(uuidgen) --memory="256m" -e="FORWARD_URL=$FORWARD_URL" -e="ENV=$ENV" -e="HOSTNAME=$(hostname -s)" -e="WORKERS=8" -e="BUFFER=256" -e="TOKEN=$TOKEN" -e="BATCHSIZE=$BATCHSIZE" -e="BATCHTIMER=5" coco/coco-splunk-http-forwarder:$DOCKER_FORWARDER_VERSION'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-filter_)" && docker stop -t 3 "$(docker ps -q --filter=name=%p-http_)"'
 Restart=on-failure

--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -3,7 +3,7 @@ Description=Splunk forwarder
 
 [Service]
 
-Environment="DOCKER_FORWARDER_VERSION=v0.0.8"
+Environment="DOCKER_FORWARDER_VERSION=v1.0.0"
 Environment="DOCKER_LOGFILTER_VERSION=v1.0.4"
 TimeoutStartSec=1200
 # Change killmode from "control-group" to "none" to let Docker remove
@@ -18,11 +18,12 @@ ExecStartPre=/bin/bash -c 'docker history coco/coco-splunk-http-forwarder:$DOCKE
 ExecStartPre=/bin/bash -c 'docker history coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION >/dev/null 2>&1 \
   || docker pull coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION'
 ExecStart=/bin/sh -c '\
-  export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_url); \
+  export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_url); \
+  export TOKEN=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_token); \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
   journalctl -a -f --since=now --output=json \
   | docker run -i --log-driver=none -e=ENV=$ENV --rm --name %p-filter_$(uuidgen) --memory="256m" coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION \
-  | docker run -i --log-driver=none --rm --name %p-http_$(uuidgen) --memory="256m" -e="FORWARD_URL=$FORWARD_URL" -e="ENV=$ENV" -e="HOSTNAME=$(hostname -s)" -e="WORKERS=12" coco/coco-splunk-http-forwarder:$DOCKER_FORWARDER_VERSION'
+  | docker run -i --log-driver=none --rm --name %p-http_$(uuidgen) --memory="256m" -e="FORWARD_URL=$FORWARD_URL" -e="ENV=$ENV" -e="HOSTNAME=$(hostname -s)" -e="WORKERS=8" -e="BUFFER=256" -e="TOKEN=$TOKEN" -e="BATCHSIZE=10" -e="BATCHTIMER=5" coco/coco-splunk-http-forwarder:$DOCKER_FORWARDER_VERSION'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-filter_)" && docker stop -t 3 "$(docker ps -q --filter=name=%p-http_)"'
 Restart=on-failure

--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -20,7 +20,7 @@ ExecStartPre=/bin/bash -c 'docker history coco/coco-logfilter:$DOCKER_LOGFILTER_
 ExecStart=/bin/sh -c '\
   export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_url); \
   export TOKEN=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_token); \
-  BATCHSIZE=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/batchsize) || BATCHSIZE=10; \
+  BATCHSIZE=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/batchsize  2>/dev/null) || BATCHSIZE=10; \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
   journalctl -a -f --since=now --output=json \
   | docker run -i --log-driver=none -e=ENV=$ENV --rm --name %p-filter_$(uuidgen) --memory="256m" coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION \


### PR DESCRIPTION
This branch upgrades splunk-forwarder service to version 1.0.0 which includes implementation for Splunk HEC client. 
This release no longer connect to splunk-forwarder cluster but instead sends events directly to Splunk Cloud.