### PR TITLE
DNS auto CR creation 2

### DIFF
--- a/cms-kafka-bridge-pub-prod-uk-sidekick@.service
+++ b/cms-kafka-bridge-pub-prod-uk-sidekick@.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=CMS Kafka Bridge Publishing Cluster Prode Sidekick
-BindsTo=cms-kafka-bridge-pub-prod@%i.service
-After=cms-kafka-bridge-pub-prod@%i.service
+Description=CMS Kafka Bridge Publishing Cluster Prod UK Sidekick
+BindsTo=cms-kafka-bridge-pub-prod-uk@%i.service
+After=cms-kafka-bridge-pub-prod-uk@%i.service
 
 [Service]
 RemainAfterExit=yes
@@ -18,9 +18,9 @@ ExecStart=/bin/sh -c "\
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
-ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/cms-kafka-bridge-pub-prod/servers/%i'
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/cms-kafka-bridge-pub-prod-uk/servers/%i'
 Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-MachineOf=cms-kafka-bridge-pub-prod@%i.service
+MachineOf=cms-kafka-bridge-pub-prod-uk@%i.service

--- a/cms-kafka-bridge-pub-prod-uk@.service
+++ b/cms-kafka-bridge-pub-prod-uk@.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=CMS Kafka Bridge Publishing Cluster Prod UK
+After=vulcan.service
+Requires=docker.service
+Wants=cms-kafka-bridge-pub-prod-uk-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker history coco/coco-kafka-bridge:$DOCKER_APP_VERSION > /dev/null 2>&1 \
+  || docker pull coco/coco-kafka-bridge:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/sh -c '\
+  export APP_PORT=8080; \
+  export QUEUE_PROXY_ADDRS="https://pub-prod-uk-up.ft.com/__kafka-rest-proxy"; \
+  export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-kafka-bridge-pub-prod-uk"; \
+  export AUTHORIZATION_KEY="Basic $(/usr/bin/etcdctl get /ft/_credentials/kafka-bridge-pub-prod/authorization_key | tr --delete \"\n\" | base64)"; \
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
+  --memory="256m" \
+  -v "/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt" \
+  --env "QUEUE_PROXY_ADDRS=$QUEUE_PROXY_ADDRS" \
+  --env "GROUP_ID=$GROUP_ID" \
+  --env "CONSUMER_AUTOCOMMIT_ENABLE=false" \
+  --env "AUTHORIZATION_KEY=$AUTHORIZATION_KEY" \
+  --env "TOPIC=NativeCmsPublicationEvents" \
+  --env "PRODUCER_HOST=http://%H:8080" \
+  --env "PRODUCER_HOST_HEADER=cms-notifier" \
+  --env "PRODUCER_TYPE=plainHTTP" \
+  coco/coco-kafka-bridge:$DOCKER_APP_VERSION;'
+
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=cms-kafka-bridge-pub-prod-uk@*.service

--- a/cms-kafka-bridge-pub-prod-us-sidekick@.service
+++ b/cms-kafka-bridge-pub-prod-us-sidekick@.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=CMS Metadata Kafka Bridge Prod Publishing Cluster Sidekick
-BindsTo=cms-metadata-kafka-bridge-pub-prod@%i.service
-After=cms-metadata-kafka-bridge-pub-prod@%i.service
+Description=CMS Kafka Bridge Publishing Cluster Prod US Sidekick
+BindsTo=cms-kafka-bridge-pub-prod-us@%i.service
+After=cms-kafka-bridge-pub-prod-us@%i.service
 
 [Service]
 RemainAfterExit=yes
@@ -9,7 +9,8 @@ ExecStart=/bin/sh -c "\
   export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
   etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
   etcdctl mkdir /ft/services/$SERVICE/servers; \
-  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set   /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set   /ft/healthcheck/$SERVICE-%i/categories lists-publish,image-publish,content-publish; \
   while [ -z $PORT ]; do \
     sleep 5; \
     CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
@@ -17,10 +18,9 @@ ExecStart=/bin/sh -c "\
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
-ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/cms-metadata-kafka-bridge-pub-prod/servers/%i'
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/cms-kafka-bridge-pub-prod-us/servers/%i'
 Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-MachineOf=cms-metadata-kafka-bridge-pub-prod@%i.service
-
+MachineOf=cms-kafka-bridge-pub-prod-us@%i.service

--- a/cms-kafka-bridge-pub-prod-us@.service
+++ b/cms-kafka-bridge-pub-prod-us@.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=CMS Metadata Kafka Bridge Publishing Cluster Prod
+Description=CMS Kafka Bridge Publishing Cluster Prod US
 After=vulcan.service
 Requires=docker.service
-Wants=cms-metadata-kafka-bridge-pub-prod-sidekick@%i.service
+Wants=cms-kafka-bridge-pub-prod-us-sidekick@%i.service
 
 [Service]
 Environment="DOCKER_APP_VERSION=latest"
@@ -16,20 +16,20 @@ ExecStartPre=/bin/bash -c 'docker history coco/coco-kafka-bridge:$DOCKER_APP_VER
 
 ExecStart=/bin/sh -c '\
   export APP_PORT=8080; \
-  export QUEUE_PROXY_ADDRS="https://publishing-prod-up.ft.com/__kafka-rest-proxy"; \
-  export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-cms-metadata-kafka-bridge-pub-prod"; \
+  export QUEUE_PROXY_ADDRS="https://pub-prod-us-up.ft.com/__kafka-rest-proxy"; \
+  export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-kafka-bridge-pub-prod-us"; \
   export AUTHORIZATION_KEY="Basic $(/usr/bin/etcdctl get /ft/_credentials/kafka-bridge-pub-prod/authorization_key | tr --delete \"\n\" | base64)"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --memory="256m" \
   -v "/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt" \
   --env "QUEUE_PROXY_ADDRS=$QUEUE_PROXY_ADDRS" \
   --env "GROUP_ID=$GROUP_ID" \
-  --env "CONSUMER_AUTOCOMMIT_ENABLE=true" \
+  --env "CONSUMER_AUTOCOMMIT_ENABLE=false" \
   --env "AUTHORIZATION_KEY=$AUTHORIZATION_KEY" \
-  --env "TOPIC=NativeCmsMetadataPublicationEvents" \
+  --env "TOPIC=NativeCmsPublicationEvents" \
   --env "PRODUCER_HOST=http://%H:8080" \
-  --env "PRODUCER_HOST_HEADER=kafka" \
-  --env "PRODUCER_TYPE=proxy" \
+  --env "PRODUCER_HOST_HEADER=cms-notifier" \
+  --env "PRODUCER_TYPE=plainHTTP" \
   coco/coco-kafka-bridge:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
@@ -37,4 +37,4 @@ Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-Conflicts=cms-metadata-kafka-bridge-pub-prod@*.service
+Conflicts=cms-kafka-bridge-pub-prod-us@*.service

--- a/cms-metadata-kafka-bridge-pub-prod-uk-sidekick@.service
+++ b/cms-metadata-kafka-bridge-pub-prod-uk-sidekick@.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=CMS Metadata Kafka Bridge Prod UK Publishing Cluster Sidekick
+BindsTo=cms-metadata-kafka-bridge-pub-prod-uk@%i.service
+After=cms-metadata-kafka-bridge-pub-prod-uk@%i.service
+
+[Service]
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "\
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  while [ -z $PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
+
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/cms-metadata-kafka-bridge-pub-prod-uk/servers/%i'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=cms-metadata-kafka-bridge-pub-prod-uk@%i.service

--- a/cms-metadata-kafka-bridge-pub-prod-uk@.service
+++ b/cms-metadata-kafka-bridge-pub-prod-uk@.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=CMS Metadata Kafka Bridge Publishing Cluster Prod UK
+After=vulcan.service
+Requires=docker.service
+Wants=cms-metadata-kafka-bridge-pub-prod-uk-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker history coco/coco-kafka-bridge:$DOCKER_APP_VERSION > /dev/null 2>&1 \
+  || docker pull coco/coco-kafka-bridge:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/sh -c '\
+  export APP_PORT=8080; \
+  export QUEUE_PROXY_ADDRS="https://pub-prod-uk-up.ft.com/__kafka-rest-proxy"; \
+  export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-cms-metadata-kafka-bridge-pub-prod-uk"; \
+  export AUTHORIZATION_KEY="Basic $(/usr/bin/etcdctl get /ft/_credentials/kafka-bridge-pub-prod/authorization_key | tr --delete \"\n\" | base64)"; \
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
+  --memory="256m" \
+  -v "/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt" \
+  --env "QUEUE_PROXY_ADDRS=$QUEUE_PROXY_ADDRS" \
+  --env "GROUP_ID=$GROUP_ID" \
+  --env "CONSUMER_AUTOCOMMIT_ENABLE=true" \
+  --env "AUTHORIZATION_KEY=$AUTHORIZATION_KEY" \
+  --env "TOPIC=NativeCmsMetadataPublicationEvents" \
+  --env "PRODUCER_HOST=http://%H:8080" \
+  --env "PRODUCER_HOST_HEADER=kafka" \
+  --env "PRODUCER_TYPE=proxy" \
+  coco/coco-kafka-bridge:$DOCKER_APP_VERSION;'
+
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=cms-metadata-kafka-bridge-pub-prod-uk@*.service

--- a/cms-metadata-kafka-bridge-pub-prod-us-sidekick@.service
+++ b/cms-metadata-kafka-bridge-pub-prod-us-sidekick@.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=CMS Metadata Kafka Bridge Prod US Publishing Cluster Sidekick
+BindsTo=cms-metadata-kafka-bridge-pub-prod-us@%i.service
+After=cms-metadata-kafka-bridge-pub-prod-us@%i.service
+
+[Service]
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "\
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  while [ -z $PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
+
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/cms-metadata-kafka-bridge-pub-prod-us/servers/%i'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=cms-metadata-kafka-bridge-pub-prod-us@%i.service

--- a/cms-metadata-kafka-bridge-pub-prod-us@.service
+++ b/cms-metadata-kafka-bridge-pub-prod-us@.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=CMS Kafka Bridge Publishing Cluster Prod
+Description=CMS Metadata Kafka Bridge Publishing Cluster Prod US
 After=vulcan.service
 Requires=docker.service
-Wants=cms-kafka-bridge-pub-prod-sidekick@%i.service
+Wants=cms-metadata-kafka-bridge-pub-prod-us-sidekick@%i.service
 
 [Service]
 Environment="DOCKER_APP_VERSION=latest"
@@ -16,20 +16,20 @@ ExecStartPre=/bin/bash -c 'docker history coco/coco-kafka-bridge:$DOCKER_APP_VER
 
 ExecStart=/bin/sh -c '\
   export APP_PORT=8080; \
-  export QUEUE_PROXY_ADDRS="https://publishing-prod-up.ft.com/__kafka-rest-proxy"; \
-  export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-kafka-bridge-pub-prod"; \
+  export QUEUE_PROXY_ADDRS="https://pub-prod-us-up.ft.com/__kafka-rest-proxy"; \
+  export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-cms-metadata-kafka-bridge-pub-prod-us"; \
   export AUTHORIZATION_KEY="Basic $(/usr/bin/etcdctl get /ft/_credentials/kafka-bridge-pub-prod/authorization_key | tr --delete \"\n\" | base64)"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --memory="256m" \
   -v "/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt" \
   --env "QUEUE_PROXY_ADDRS=$QUEUE_PROXY_ADDRS" \
   --env "GROUP_ID=$GROUP_ID" \
-  --env "CONSUMER_AUTOCOMMIT_ENABLE=false" \
+  --env "CONSUMER_AUTOCOMMIT_ENABLE=true" \
   --env "AUTHORIZATION_KEY=$AUTHORIZATION_KEY" \
-  --env "TOPIC=NativeCmsPublicationEvents" \
+  --env "TOPIC=NativeCmsMetadataPublicationEvents" \
   --env "PRODUCER_HOST=http://%H:8080" \
-  --env "PRODUCER_HOST_HEADER=cms-notifier" \
-  --env "PRODUCER_TYPE=plainHTTP" \
+  --env "PRODUCER_HOST_HEADER=kafka" \
+  --env "PRODUCER_TYPE=proxy" \
   coco/coco-kafka-bridge:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
@@ -37,4 +37,4 @@ Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-Conflicts=cms-kafka-bridge-pub-prod@*.service
+Conflicts=cms-metadata-kafka-bridge-pub-prod-us@*.service

--- a/methode-image-binary-transformer@.service
+++ b/methode-image-binary-transformer@.service
@@ -16,8 +16,10 @@ ExecStartPre=/bin/bash -c 'docker history up-registry.ft.com/coco/methode-image-
   || docker pull up-registry.ft.com/coco/methode-image-binary-transformer:$DOCKER_APP_VERSION'
 
 ExecStart=/bin/sh -c '\
-  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
-  --env "VULCAN_HOST=$HOSTNAME:8080" \
+  export JAVA_OPTS="-Xms256m -Xmx256m -XX:+UseG1GC -server"; \
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -P \
+  --env "JAVA_OPTS=$JAVA_OPTS" \
+  --env "VULCAN_HOST=%H" \
   up-registry.ft.com/coco/methode-image-binary-transformer:$DOCKER_APP_VERSION'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/services.yaml
+++ b/services.yaml
@@ -211,7 +211,7 @@ services:
 - name: methode-article-transformer-sidekick@.service
   count: 2
 - name: methode-article-transformer@.service
-  version: v82
+  version: v83
   count: 2
 - name: methode-content-importer-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -47,14 +47,24 @@ services:
 - name: burrow@.service
   version: v1.0.1
   count: 1
-- name: cms-kafka-bridge-pub-prod-sidekick@.service
+- name: cms-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
-- name: cms-kafka-bridge-pub-prod@.service
+- name: cms-kafka-bridge-pub-prod-uk@.service
   version: v13.0.0
   count: 2
-- name: cms-metadata-kafka-bridge-pub-prod-sidekick@.service
+- name: cms-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
-- name: cms-metadata-kafka-bridge-pub-prod@.service
+- name: cms-kafka-bridge-pub-prod-us@.service
+  version: v13.0.0
+  count: 2
+- name: cms-metadata-kafka-bridge-pub-prod-uk-sidekick@.service
+  count: 2
+- name: cms-metadata-kafka-bridge-pub-prod-uk@.service
+  version: v13.0.0
+  count: 2
+- name: cms-metadata-kafka-bridge-pub-prod-us-sidekick@.service
+  count: 2
+- name: cms-metadata-kafka-bridge-pub-prod-us@.service
   version: v13.0.0
   count: 2
 - name: cms-notifier-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -146,7 +146,7 @@ services:
   count: 2
   sequentialDeployment: true
 - name: elb-dns-registrator.service
-  version: v4.0.1
+  version: v4.0.2
 - name: elb-presence@.service
   count: 2
 - name: enriched-content-read-api-sidekick@.service
@@ -442,7 +442,7 @@ services:
   version: v1.1.3
   count: 1
 - name: tunnel-registrator.service
-  version: v1.0.1
+  version: v1.0.2
 - name: up-queue-sender-v1-metadata-sidekick@.service
   count: 1
 - name: up-queue-sender-v1-metadata@.service

--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -3,7 +3,7 @@ Description=Splunk forwarder
 
 [Service]
 
-Environment="DOCKER_FORWARDER_VERSION=v0.0.8"
+Environment="DOCKER_FORWARDER_VERSION=v1.0.1"
 Environment="DOCKER_LOGFILTER_VERSION=v1.0.4"
 TimeoutStartSec=1200
 # Change killmode from "control-group" to "none" to let Docker remove
@@ -18,11 +18,13 @@ ExecStartPre=/bin/bash -c 'docker history coco/coco-splunk-http-forwarder:$DOCKE
 ExecStartPre=/bin/bash -c 'docker history coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION >/dev/null 2>&1 \
   || docker pull coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION'
 ExecStart=/bin/sh -c '\
-  export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_url); \
+  export FORWARD_URL=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_url); \
+  export TOKEN=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/splunk_hec_token); \
+  BATCHSIZE=$(/usr/bin/etcdctl get /ft/config/splunk-forwarder/batchsize  2>/dev/null) || BATCHSIZE=10; \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
   journalctl -a -f --since=now --output=json \
   | docker run -i --log-driver=none -e=ENV=$ENV --rm --name %p-filter_$(uuidgen) --memory="256m" coco/coco-logfilter:$DOCKER_LOGFILTER_VERSION \
-  | docker run -i --log-driver=none --rm --name %p-http_$(uuidgen) --memory="256m" -e="FORWARD_URL=$FORWARD_URL" -e="ENV=$ENV" -e="HOSTNAME=$(hostname -s)" -e="WORKERS=12" coco/coco-splunk-http-forwarder:$DOCKER_FORWARDER_VERSION'
+  | docker run -i --log-driver=none --rm --name %p-http_$(uuidgen) --memory="256m" -e="FORWARD_URL=$FORWARD_URL" -e="ENV=$ENV" -e="HOSTNAME=$(hostname -s)" -e="WORKERS=8" -e="BUFFER=256" -e="TOKEN=$TOKEN" -e="BATCHSIZE=$BATCHSIZE" -e="BATCHTIMER=5" coco/coco-splunk-http-forwarder:$DOCKER_FORWARDER_VERSION'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-filter_)" && docker stop -t 3 "$(docker ps -q --filter=name=%p-http_)"'
 Restart=on-failure

--- a/v1-content-annotator-binding-service-blue@.service
+++ b/v1-content-annotator-binding-service-blue@.service
@@ -21,6 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  export JAVA_OPTS="-Xms128m -Xmx128m -XX:+UseG1GC -server"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --env "TOPIC=ConceptSuggestions" \
   --env "GROUP_ID=$GROUP_ID" \
@@ -29,6 +30,7 @@ ExecStart=/bin/sh -c '\
   --env "WRITER_ENDPOINT=$HOSTNAME:8080:8080" \
   --env "ANNOTATING_SYSTEM=http://cmdb.ft.com/systems/binding-service" \
   --env "WRITER_HOST_HEADER=v1-annotations-rw-blue" \
+  --env "JAVA_OPTS=$JAVA_OPTS" \
   up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/v1-content-annotator-binding-service-red@.service
+++ b/v1-content-annotator-binding-service-red@.service
@@ -21,6 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  export JAVA_OPTS="-Xms128m -Xmx128m -XX:+UseG1GC -server"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --env "TOPIC=ConceptSuggestions" \
   --env "GROUP_ID=$GROUP_ID" \
@@ -29,6 +30,7 @@ ExecStart=/bin/sh -c '\
   --env "WRITER_ENDPOINT=$HOSTNAME:8080:8080" \
   --env "ANNOTATING_SYSTEM=http://cmdb.ft.com/systems/binding-service" \
   --env "WRITER_HOST_HEADER=v1-annotations-rw-red" \
+  --env "JAVA_OPTS=$JAVA_OPTS" \
   up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/v1-content-annotator-blue@.service
+++ b/v1-content-annotator-blue@.service
@@ -21,6 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  export JAVA_OPTS="-Xms128m -Xmx128m -XX:+UseG1GC -server"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --env "TOPIC=ConceptSuggestions" \
   --env "GROUP_ID=$GROUP_ID" \
@@ -29,6 +30,7 @@ ExecStart=/bin/sh -c '\
   --env "WRITER_ENDPOINT=$HOSTNAME:8080:8080" \
   --env "ANNOTATING_SYSTEM=http://cmdb.ft.com/systems/methode-web-pub" \
   --env "WRITER_HOST_HEADER=v1-annotations-rw-blue" \
+  --env "JAVA_OPTS=$JAVA_OPTS" \
   up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/v1-content-annotator-brightcove-blue@.service
+++ b/v1-content-annotator-brightcove-blue@.service
@@ -19,6 +19,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  export JAVA_OPTS="-Xms128m -Xmx128m -XX:+UseG1GC -server"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
     --env "TOPIC=ConceptSuggestions" \
     --env "GROUP_ID=$GROUP_ID" \
@@ -27,6 +28,7 @@ ExecStart=/bin/sh -c '\
     --env "WRITER_ENDPOINT=$HOSTNAME:8080:8080" \
     --env "ANNOTATING_SYSTEM=http://cmdb.ft.com/systems/brightcove" \
     --env "WRITER_HOST_HEADER=v1-annotations-rw-blue" \
+    --env "JAVA_OPTS=$JAVA_OPTS" \
     up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
 Restart=on-failure

--- a/v1-content-annotator-brightcove-red@.service
+++ b/v1-content-annotator-brightcove-red@.service
@@ -19,6 +19,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  export JAVA_OPTS="-Xms128m -Xmx128m -XX:+UseG1GC -server"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
     --env "TOPIC=ConceptSuggestions" \
     --env "GROUP_ID=$GROUP_ID" \
@@ -27,6 +28,7 @@ ExecStart=/bin/sh -c '\
     --env "WRITER_ENDPOINT=$HOSTNAME:8080:8080" \
     --env "ANNOTATING_SYSTEM=http://cmdb.ft.com/systems/brightcove" \
     --env "WRITER_HOST_HEADER=v1-annotations-rw-red" \
+    --env "JAVA_OPTS=$JAVA_OPTS" \
     up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
 Restart=on-failure

--- a/v1-content-annotator-red@.service
+++ b/v1-content-annotator-red@.service
@@ -21,6 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  export JAVA_OPTS="-Xms128m -Xmx128m -XX:+UseG1GC -server"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --env "TOPIC=ConceptSuggestions" \
   --env "GROUP_ID=$GROUP_ID" \
@@ -29,6 +30,7 @@ ExecStart=/bin/sh -c '\
   --env "WRITER_ENDPOINT=$HOSTNAME:8080:8080" \
   --env "ANNOTATING_SYSTEM=http://cmdb.ft.com/systems/methode-web-pub" \
   --env "WRITER_HOST_HEADER=v1-annotations-rw-red" \
+  --env "JAVA_OPTS=$JAVA_OPTS" \
   up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/v2-content-annotator-blue@.service
+++ b/v2-content-annotator-blue@.service
@@ -21,6 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  export JAVA_OPTS="-Xms128m -Xmx128m -XX:+UseG1GC -server"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --env "TOPIC=ConceptSuggestions" \
   --env "GROUP_ID=$GROUP_ID" \
@@ -29,6 +30,7 @@ ExecStart=/bin/sh -c '\
   --env "WRITER_ENDPOINT=$HOSTNAME:8080:8080" \
   --env "ANNOTATING_SYSTEM=concept-suggestor" \
   --env "WRITER_HOST_HEADER=v2-annotations-rw-blue" \
+  --env "JAVA_OPTS=$JAVA_OPTS" \
   up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/v2-content-annotator-red@.service
+++ b/v2-content-annotator-red@.service
@@ -21,6 +21,7 @@ ExecStart=/bin/sh -c '\
   export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
   export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
   export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  export JAVA_OPTS="-Xms128m -Xmx128m -XX:+UseG1GC -server"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --env "TOPIC=ConceptSuggestions" \
   --env "GROUP_ID=$GROUP_ID" \
@@ -29,6 +30,7 @@ ExecStart=/bin/sh -c '\
   --env "WRITER_ENDPOINT=$HOSTNAME:8080:8080" \
   --env "ANNOTATING_SYSTEM=concept-suggestor" \
   --env "WRITER_HOST_HEADER=v2-annotations-rw-red" \
+  --env "JAVA_OPTS=$JAVA_OPTS" \
   up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'


### PR DESCRIPTION
Automatically raise CRs when deleting DNS records via Konstructor.

Currently uses my own email address due to limitations in Salesforce - have requested a service account to be set up so that we can use a group email instead, but that might take a week or longer.
