### PR TITLE
Update DNS services to automagically raise CRs

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -146,7 +146,7 @@ services:
   count: 2
   sequentialDeployment: true
 - name: elb-dns-registrator.service
-  version: v4.0.1
+  version: v4.0.2
 - name: elb-presence@.service
   count: 2
 - name: enriched-content-read-api-sidekick@.service
@@ -442,7 +442,7 @@ services:
   version: v1.1.3
   count: 1
 - name: tunnel-registrator.service
-  version: v1.0.1
+  version: v1.0.2
 - name: up-queue-sender-v1-metadata-sidekick@.service
   count: 1
 - name: up-queue-sender-v1-metadata@.service


### PR DESCRIPTION
Automatically raise CRs when deleting DNS records via Konstructor.

Currently uses my own email address due to limitations in Salesforce - have requested a service account to be set up so that we can use a group email instead, but that might take a week or longer.
