### PR TITLE
Upgrade binary-ingester to v97

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -24,7 +24,7 @@ services:
 - name: binary-ingester-sidekick@.service
   count: 2
 - name: binary-ingester@.service
-  version: v92
+  version: v97
   count: 2
 - name: binary-writer-sidekick@.service
   count: 2


### PR DESCRIPTION
- see PR http://git.svc.ft.com/projects/CP/repos/binary-ingester/pull-requests/40/overview 
- versions between 92 and 97 are DH fails, no changes
- tried in XP, still works