### PR TITLE
Bumped the version to include the addition of the v1 org metadata

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -496,7 +496,7 @@ services:
 - name: v1-suggestor-sidekick@.service
   count: 2
 - name: v1-suggestor@.service
-  version: v0.0.14
+  version: v0.0.15
   count: 2
 - name: v2-annotations-rw-blue-sidekick@.service
   count: 1


### PR DESCRIPTION
Allow organisations v1 major mentions to come through from TME/QMI
https://github.com/Financial-Times/v1-suggestor/pull/21
