### PR TITLE
Adding Major Mentions to the public annotations-api

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -333,7 +333,7 @@ services:
 - name: public-annotations-api-sidekick@.service
   count: 2
 - name: public-annotations-api@.service
-  version: v0.0.16
+  version: v0.0.17
   count: 2
   sequentialDeployment: true
 - name: public-brands-api-sidekick@.service


### PR DESCRIPTION
Added major mentions so V1 organisation annotations can also be surfaced in enrichedcontent

https://github.com/Financial-Times/public-annotations-api/pull/11
