### PR TITLE
Bumping version of the concept ingester to remove topic check in healthcheck

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -75,12 +75,12 @@ services:
 - name: concept-ingester-blue-sidekick@.service
   count: 1
 - name: concept-ingester-blue@.service
-  version: v1.1.7
+  version: v1.1.8
   count: 1
 - name: concept-ingester-red-sidekick@.service
   count: 1
 - name: concept-ingester-red@.service
-  version: v1.1.7
+  version: v1.1.8
   count: 1
 - name: concept-suggestions-kafka-bridge-sidekick@.service
   count: 2


### PR DESCRIPTION
When provisioning a new cluster this component's healthcheck was checking if a topic was present which was unnecessary for this component and created noise

https://github.com/Financial-Times/concept-ingester/pull/15