### PR TITLE
Add rec reads content annotator

### DIFF
--- a/rec-reads-content-annotator-sidekick@.service
+++ b/rec-reads-content-annotator-sidekick@.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Recommended Reads Content Annotator Service Sidekick
+BindsTo=rec-reads-content-annotator@%i.service
+After=rec-reads-content-annotator@%i.service
+
+[Service]
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "\
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  while [ -z $PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
+
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/rec-reads-content-annotator/servers/%i'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=rec-reads-content-annotator@%i.service

--- a/rec-reads-content-annotator@.service
+++ b/rec-reads-content-annotator@.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=Recommended Reads Content Annotator Service
+After=vulcan.service
+Requires=docker.service
+Wants=rec-reads-content-annotator-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c '/usr/bin/docker history up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION > /dev/null 2>&1 \
+  || /usr/bin/docker pull up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/sh -c '\
+  export APP_PORT=8080; \
+  export GROUP_ID=$(/usr/bin/etcdctl get /ft/config/environment_tag)"-rec-reads-content-annotator"; \
+  export ZOOKEEPER_HOST=$(/usr/bin/etcdctl get /ft/config/zookeeper/ip); \
+  export ZOOKEEPER_PORT=$(/usr/bin/etcdctl get /ft/config/zookeeper/port); \
+  export KAFKA_HOST=$(/usr/bin/etcdctl get /ft/config/kafka/ip); \
+  export KAFKA_PORT=$(/usr/bin/etcdctl get /ft/config/kafka/port); \
+  export JAVA_OPTS="-Xms256m -Xmx256m -XX:+UseG1GC -server"; \
+  export WRITER_HOST=$(/usr/bin/etcdctl get /ft/config/upp-gateway/host); \
+  export WRITER_PORT=$(/usr/bin/etcdctl get /ft/config/upp-gateway/port); \
+  export WRITER_CREDENTIALS=$(usr/bin/etcdctl get /ft/_credentials/upp-gateway/authorization_key); \
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
+  --env "TOPIC=ConceptSuggestions" \
+  --env "GROUP_ID=$GROUP_ID" \
+  --env "ZOOKEEPER_ENDPOINTS=$ZOOKEEPER_HOST:$ZOOKEEPER_PORT" \
+  --env "KAFKA_ENDPOINTS=$KAFKA_HOST:$KAFKA_PORT" \
+  --env "WRITER_PATH=/rr-suggestions" \
+  --env "WRITER_ENDPOINT=$WRITER_HOST:$WRITER_PORT" \
+  --env "WRITER_CREDENTIALS=$WRITER_CREDENTIALS" \
+  --env "WRITER_HOST_HEADER=upp-gateway" \
+  --env "WRITER_HEALTHCHECK_PATH=/build-info" \
+  --env "ANNOTATING_SYSTEM=concept-suggestor" \
+  --env "JAVA_OPTS=$JAVA_OPTS" \
+  --env "FILTER_NOVELTIES=false" \
+  up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
+
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=rec-reads-content-annotator@*.service

--- a/services.yaml
+++ b/services.yaml
@@ -393,6 +393,11 @@ services:
   count: 1
 - name: rec-reads-content-ingester-sidekick@.service
   count: 1
+- name: rec-reads-content-annotator@.service
+  version: v44
+  count: 1
+- name: rec-reads-content-annotator-sidekick@.service
+  count: 1
 - name: restorage-mongo-sidekick@.service
   count: 1
 - name: restorage-mongo@.service
@@ -544,7 +549,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v91
+  version: v90
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
Adding Recommended Reads content annotator to coco clusters as we migrate suggestions flow from non-coco. This service will read ConceptSuggestions topic and send annotations to rr-suggestions-indexer in ftp2 via varnish and elb.