### PR TITLE
Removed coupling to apiUrl for WP articles

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -534,7 +534,7 @@ services:
 - name: wordpress-article-transformer-sidekick@.service
   count: 2
 - name: wordpress-article-transformer@.service
-  version: v90
+  version: v91
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
http://git.svc.ft.com/projects/CP/repos/wordpress-article-transformer/commits/238e5e380ec8cd2227cf3e6f933ed448addbd8d5