### PR TITLE
Fixed orphan container problem for mongo-backup

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -275,7 +275,7 @@ services:
   version: v6
   count: 2
 - name: mongo-backup@.service
-  version: v20.0.0
+  version: v20.0.1
   count: 3
   desiredState: loaded
 - name: mongo-backup@.timer


### PR DESCRIPTION
Fixed orphan container problem for mongo-backup. Changes can be found here: https://github.com/Financial-Times/coco-mongodb-backup/pull/16