### PR TITLE
Explicitly used version 3.0.2 for MongoDB

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -288,6 +288,7 @@ services:
 - name: mongodb-sidekick@.service
   count: 3
 - name: mongodb@.service
+  version: v3.0.2
   count: 3
   sequentialDeployment: true
 - name: nativerw-sidekick@.service


### PR DESCRIPTION
To see more details and code changes, follow this link:  https://github.com/Financial-Times/coco-mongodb/pull/3