### PR TITLE
Delay shutdown of notifications-rw for deferred writes.

### DIFF
--- a/notifications-rw@.service
+++ b/notifications-rw@.service
@@ -27,7 +27,7 @@ ExecStart=/bin/sh -c '\
     --env "CACHE_TTL=$(/usr/bin/etcdctl get /ft/config/cache-max-age)" \
     up-registry.ft.com/coco/notifications-rw:$DOCKER_APP_VERSION;'
 
-ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
+ExecStop=-/bin/bash -c 'docker stop -t $(( $(/usr/bin/etcdctl get /ft/config/cache-max-age) + 1 )) "$(docker ps -q --filter=name=%p-%i_)"'
 Restart=on-failure
 RestartSec=60
 

--- a/services.yaml
+++ b/services.yaml
@@ -333,7 +333,7 @@ services:
 - name: notifications-rw-sidekick@.service
   count: 2
 - name: notifications-rw@.service
-  version: v54
+  version: v55
   count: 2
   sequentialDeployment: true
 - name: organisations-rw-neo4j-blue-sidekick@.service


### PR DESCRIPTION
PR for dynpub. See
http://git.svc.ft.com/projects/CP/repos/notifications-rw/pull-requests/52/overview. Wait a maximum of 1s more than the cache max-age before forcing shutdown.