### PR TITLE
Renamed public-six-degrees to public-six-degrees-api. Bump version

### DIFF
--- a/public-six-degrees-api-sidekick@.service
+++ b/public-six-degrees-api-sidekick@.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=Public Six Degrees Service Sidekick
-BindsTo=public-six-degrees@%i.service
-After=public-six-degrees@%i.service
+Description=Public Six Degrees Api Service Sidekick
+BindsTo=public-six-degrees-api@%i.service
+After=public-six-degrees-api@%i.service
 
 [Service]
 RemainAfterExit=yes
@@ -20,9 +20,9 @@ ExecStart=/bin/sh -c "\
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
 
-ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/public-six-degrees/servers/%i'
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/public-six-degrees-api/servers/%i'
 Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-MachineOf=public-six-degrees@%i.service
+MachineOf=public-six-degrees-api@%i.service

--- a/public-six-degrees-api@.service
+++ b/public-six-degrees-api@.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=Public Six Degrees Service
+Description=Public Six Degrees Api Service
 After=vulcan.service
 Requires=docker.service
-Wants=public-six-degrees-sidekick@%i.service
+Wants=public-six-degrees-api-sidekick@%i.service
 
 [Service]
 Environment="DOCKER_APP_VERSION=latest"
@@ -22,7 +22,7 @@ ExecStart=/bin/sh -c '\
   -e "NEO_URL=http://$HOSTNAME:8080/__neo4j-read/db/data" \
   -e "APP_PORT=$APP_PORT" \
   -e "GRAPHITE_ADDRESS=graphite.ft.com:2003" \
-  -e "GRAPHITE_PREFIX=coco.services.$ENV.public-six-degrees.%i" \
+  -e "GRAPHITE_PREFIX=coco.services.$ENV.public-six-degrees-api.%i" \
   -e "LOG_METRICS=false" \
   -e "CACHE_DURATION=24h" \
   coco/public-six-degrees:$DOCKER_APP_VERSION;'
@@ -32,4 +32,4 @@ Restart=on-failure
 RestartSec=60
 
 [X-Fleet]
-Conflicts=public-six-degrees@*.service
+Conflicts=public-six-degrees-api@*.service

--- a/services.yaml
+++ b/services.yaml
@@ -392,10 +392,10 @@ services:
   version: v0.1.7
   count: 2
   sequentialDeployment: true
-- name: public-six-degrees-sidekick@.service
+- name: public-six-degrees-api-sidekick@.service
   count: 2
-- name: public-six-degrees@.service
-  version: 0.0.6
+- name: public-six-degrees-api@.service
+  version: 1.0.0
   count: 2
   sequentialDeployment: true
 - name: public-things-api-sidekick@.service


### PR DESCRIPTION
See https://github.com/Financial-Times/public-six-degrees/releases/tag/1.0.0 - "productionized" app

Manual steps after deployment:

```
etcdctl rm --recursive /ft/healthcheck/public-six-degrees-1
etcdctl rm --recursive /ft/healthcheck/public-six-degrees-2
etcdctl rm --recursive /ft/services/public-six-degrees
``` 
Sometimes `aggregate-healthcheck` fails to read etcd value changes (don't know why), so a restart of that might needed

Tested in XP.