### PR TITLE
notifications: fix units' stop cmd

### DIFF
--- a/notifications-push@.service
+++ b/notifications-push@.service
@@ -9,8 +9,8 @@ Environment="DOCKER_APP_VERSION=latest"
 TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps --filter=name=%p-%i_ --format "{{ .Names }}" | grep ^%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps --filter=name=%p-%i_ --format "{{ .Names }}" | grep ^%p-%i_)" > /dev/null 2>&1'
 ExecStartPre=/bin/bash -c 'docker history coco/notifications-push:$DOCKER_APP_VERSION > /dev/null 2>&1 \
    || docker pull coco/notifications-push:$DOCKER_APP_VERSION'
 
@@ -31,7 +31,7 @@ ExecStart=/bin/sh -c '\
       --env "WHITELIST=^http://(methode|wordpress)-article-(transformer|mapper)(-pr|-iw)?(-uk-.*)?\.svc\.ft\.com(:\d{2,5})?/(content)/[\w-]+.*$" \
       coco/notifications-push:$DOCKER_APP_VERSION;'
 
-ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps --filter=name=%p-%i_ --format "{{ .Names }}" | grep ^%p-%i_)"'
 Restart=on-failure
 RestartSec=60
 

--- a/notifications-rw@.service
+++ b/notifications-rw@.service
@@ -10,8 +10,8 @@ TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
-ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps --filter=name=%p-%i_ --format "{{ .Names }}" | grep ^%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps --filter=name=%p-%i_ --format "{{ .Names }}" | grep ^%p-%i_)" > /dev/null 2>&1'
 ExecStartPre=/bin/bash -c "docker history up-registry.ft.com/coco/notifications-rw:$DOCKER_APP_VERSION > /dev/null 2>&1 \
   || docker pull up-registry.ft.com/coco/notifications-rw:$DOCKER_APP_VERSION"
 
@@ -27,7 +27,7 @@ ExecStart=/bin/sh -c '\
     --env "CACHE_TTL=$(/usr/bin/etcdctl get /ft/config/cache-max-age)" \
     up-registry.ft.com/coco/notifications-rw:$DOCKER_APP_VERSION;'
 
-ExecStop=-/bin/bash -c 'docker stop -t $(( $(/usr/bin/etcdctl get /ft/config/cache-max-age) + 1 )) "$(docker ps -q --filter=name=%p-%i_)"'
+ExecStop=-/bin/bash -c 'docker stop -t $(( $(/usr/bin/etcdctl get /ft/config/cache-max-age) + 1 )) "$(docker ps --filter=name=%p-%i_ --format "{{ .Names }}" | grep ^%p-%i_)"'
 Restart=on-failure
 RestartSec=60
 


### PR DESCRIPTION
Stopping `notifications-push` has not been working since `list-notifications-push` was deployed. It turns out that container filtering in case of overlapping unit names is not restrictive enough.

The same could happen with `notifications-rw` if `list-notifications-rw` runs on the same machine.

This could happen with any new overlapping unit name.