### PR TITLE
Update concept-rw-elasticsearch to v0.0.10 - consistent status codes

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -85,7 +85,7 @@ services:
 - name: concept-rw-elasticsearch-sidekick@.service
   count: 2
 - name: concept-rw-elasticsearch@.service
-  version: v0.0.9
+  version: v0.0.10
   count: 2
   sequentialDeployment: true
 - name: concept-search-api-sidekick@.service


### PR DESCRIPTION
Using 200 instead of 202 - for ingester to accept.