### PR TITLE
Methode api etcd

### DIFF
--- a/content-preview@.service
+++ b/content-preview@.service
@@ -19,7 +19,7 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/content-preview:$DOCKER_
 ExecStart=/bin/sh -c '\
     export MAPI_AUTH=$(/usr/bin/etcdctl get /ft/_credentials/methode-api/authorization_key); \
     export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
-    export METHODE_API=$(/usr/bin/etcdctl get /ft/config/methode_api); \
+    export METHODE_API=$(/usr/bin/etcdctl get /ft/config/methode-api); \
     /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
 	--memory="256m" \
     --env "APP_PORT=8080" \

--- a/content-preview@.service
+++ b/content-preview@.service
@@ -19,14 +19,15 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/content-preview:$DOCKER_
 ExecStart=/bin/sh -c '\
     export MAPI_AUTH=$(/usr/bin/etcdctl get /ft/_credentials/methode-api/authorization_key); \
     export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
+    export METHODE_API=$(/usr/bin/etcdctl get /ft/config/methode_api); \
     /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
 	--memory="256m" \
     --env "APP_PORT=8080" \
     --env "SOURCE_APP_AUTH=$MAPI_AUTH" \
-    --env "SOURCE_APP_URI=https://methodeapi.glb.ft.com/eom-file/" \
+    --env "SOURCE_APP_URI=$METHODE_API/eom-file/" \
     --env "TRANSFORM_APP_URI=http://$HOSTNAME:8080/content-transform/" \
     --env "TRANSFORM_APP_HOST_HEADER=methode-article-transformer" \
-    --env "SOURCE_APP_HEALTH_URI=https://methodeapi.glb.ft.com/build-info" \
+    --env "SOURCE_APP_HEALTH_URI=$METHODE_API/build-info" \
     --env "TRANSFORM_APP_HEALTH_URI=http://$HOSTNAME:8080/__health" \
     --env "SOURCE_APP_NAME=methode-api" \
     --env "TRANSFORM_APP_NAME=methode-article-transformer" \


### PR DESCRIPTION
* remember to create the keys in existing environments, pre-prod, prod-uk, prod-us - `etcdctl set /ft/config/methode-api https://...`

Goes with https://github.com/Financial-Times/coco-provisioner/pull/161