### PR TITLE
Bugfix/fix tearsheet org urls

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -133,7 +133,7 @@ services:
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v54
+  version: v55
   count: 2
   sequentialDeployment: true
 - name: content-rw-neo4j-blue-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -127,7 +127,7 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v54
+  version: v55
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
@@ -258,7 +258,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: v1.0.7
+  version: v1.0.8
   count: 2
 - name: methode-content-importer-sidekick@.service
   count: 2


### PR DESCRIPTION
I tested this last week and it worked fine in dynpub/pre-prod. Articles containing companies tags (set in Test Methode Client) now reach our Document Store containing URLs to test.api.ft.com/../ instead of api.ft.com/.../ where relevant.