### PR TITLE
Bumped the version to ensure all the code from recent merges 

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -398,7 +398,7 @@ services:
 - name: public-concordances-api-sidekick@.service
   count: 2
 - name: public-concordances-api@.service
-  version: v0.1.5
+  version: v0.1.6
   count: 2
   sequentialDeployment: true
 - name: public-content-by-concept-api-sidekick@.service


### PR DESCRIPTION
and conflict resolution gets pushed through

https://github.com/Financial-Times/public-concordances-api/pull/5