### PR TITLE
Improve log filter for PAM TIDs

### DIFF
--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -4,7 +4,7 @@ Description=Splunk forwarder
 [Service]
 
 Environment="DOCKER_FORWARDER_VERSION=v1.0.2"
-Environment="DOCKER_LOGFILTER_VERSION=v1.0.7"
+Environment="DOCKER_LOGFILTER_VERSION=v1.1.2"
 TimeoutStartSec=1200
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.


### PR DESCRIPTION
This [commit](https://github.com/Financial-Times/publish-availability-monitor/commit/41a5fa252ab16414094c8a5951d823c323b29bc8) improves PAMs transaction ID generation, so it's clear which publish is being monitored for each request. 

A side-effect is that we need to remove the character restrictions for PAM txids in the logfilter.
