### PR TITLE
Rolled back to version 19 

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -386,7 +386,7 @@ services:
 - name: public-annotations-api-sidekick@.service
   count: 2
 - name: public-annotations-api@.service
-  version: v0.0.20
+  version: v0.0.19
   count: 2
   sequentialDeployment: true
 - name: public-brands-api-sidekick@.service


### PR DESCRIPTION
as there is a bug with 20 that means that no annotations are returned if the brands have no parents ie. if only has FT as brand as all other brands have FT as their parent