### PR TITLE
Fixed sidekick for content-ingester

### DIFF
--- a/content-ingester-sidekick@.service
+++ b/content-ingester-sidekick@.service
@@ -13,7 +13,7 @@ ExecStart=/bin/sh -c "\
   etcdctl set /ft/healthcheck/$SERVICE-%i/categories lists-publish,image-publish,content-publish; \
   while [ -z $PORT ]; do \
     sleep 5; \
-    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+    CONTAINER_NAME=$(docker ps -q --filter=name=^/\"$SERVICE\"-%i_); \
     PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
   done; \
   etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"


### PR DESCRIPTION
This is a well know issue regarding services that contains substrings of other service names.