### PR TITLE
Bump public-annotations-api to v0.0.21

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -396,7 +396,7 @@ services:
 - name: public-annotations-api-sidekick@.service
   count: 2
 - name: public-annotations-api@.service
-  version: v0.0.19
+  version: v0.0.21
   count: 2
   sequentialDeployment: true
 - name: public-brands-api-sidekick@.service


### PR DESCRIPTION
Fix for issue where content only has a parent brand.
https://github.com/Financial-Times/public-annotations-api/pull/14