### PR TITLE
Disabled the timeout logic for SystemD killing Neo4J

### DIFF
--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -30,7 +30,7 @@ ExecStart=/bin/sh -c "\
     --env "GRAPHITE_PREFIX=coco.services.$ENV.neo4j-blue.%i" \
     coco/ft-neo4j:$DOCKER_APP_VERSION"
 
-ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'
+ExecStop=-/bin/bash -c 'docker stop -t 90 "$(docker ps -q --filter=name=^/%p-%i_)"'
 Restart=on-failure
 RestartSec=60
 

--- a/neo4j-blue@.service
+++ b/neo4j-blue@.service
@@ -7,6 +7,7 @@ Wants=neo4j-blue-sidekick@%i.service neo4j-read-blue-sidekick@%i.service
 [Service]
 Environment="DOCKER_APP_VERSION=latest"
 TimeoutStartSec=0
+TimeoutStopSec=infinity
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none

--- a/neo4j-red@.service
+++ b/neo4j-red@.service
@@ -30,7 +30,7 @@ ExecStart=/bin/sh -c "\
     --env "GRAPHITE_PREFIX=coco.services.$ENV.neo4j-red.%i" \
     coco/ft-neo4j:$DOCKER_APP_VERSION"
 
-ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'
+ExecStop=-/bin/bash -c 'docker stop -t 90 "$(docker ps -q --filter=name=^/%p-%i_)"'
 Restart=on-failure
 RestartSec=60
 

--- a/neo4j-red@.service
+++ b/neo4j-red@.service
@@ -9,6 +9,7 @@ Environment="DOCKER_APP_VERSION=latest"
 TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
+TimeoutStopSec=infinity
 KillMode=none
 ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'


### PR DESCRIPTION
Disabled the timeout logic for killing processes to avoid corruption of the datastore due to systemd killing the Neo instance. The systemd default is 90s before it issues a SIGKILL and the datastore may have grown just enough that it takes longer than 90s. Setting to infinity allows the service to shutdown in its own time and so a nasty shutdown and subsequent corruption should be avoided

http://unix.stackexchange.com/questions/227017/how-to-change-systemd-service-timeout-value