### PR TITLE
Increased memory for methode-image-binary-ingester due to prod issue

### DIFF
--- a/methode-image-binary-mapper@.service
+++ b/methode-image-binary-mapper@.service
@@ -15,7 +15,7 @@ ExecStartPre=/bin/sh -c 'docker history coco/methode-image-binary-mapper:$DOCKER
   || docker pull coco/methode-image-binary-mapper:$DOCKER_APP_VERSION'
 
 ExecStart=/bin/sh -c '\
-  export JAVA_OPTS="-Xms256m -Xmx256m -XX:+UseG1GC -server"; \
+  export JAVA_OPTS="-Xms296m -Xmx296m -XX:+UseG1GC -server"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
   --env "JAVA_OPTS=$JAVA_OPTS" \
   --env "KAFKA_PROXY=$HOSTNAME:8080" \


### PR DESCRIPTION
This change should prevent the prod issue that we had to publish big images.