### PR TITLE
Varnish version bump to 0.1.7

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -592,7 +592,7 @@ services:
   version: v53
   count: 1
 - name: varnish@.service
-  version: v0.1.6
+  version: v0.1.7-rj
   count: 2
   sequentialDeployment: true
 - name: video-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -592,7 +592,7 @@ services:
   version: v53
   count: 1
 - name: varnish@.service
-  version: v0.1.7-rj
+  version: v0.1.7
   count: 2
   sequentialDeployment: true
 - name: video-mapper-sidekick@.service


### PR DESCRIPTION
New Varnish version which has request limit set for internalcontent-preview
https://github.com/Financial-Times/delivery-varnish/pull/9