### PR TITLE
MAM version change.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -273,7 +273,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: v1.0.10
+  version: v1.0.13
   count: 2
 - name: methode-content-importer-sidekick@.service
   count: 2


### PR DESCRIPTION
v1.0.13 contains the build-info fix from v1.0.12, but not the other
changes that were present in v1.0.11. See
https://github.com/Financial-Times/methode-article-mapper/pull/11