### PR TITLE
Add suggestions endpoint to content annotator

### DIFF
--- a/rec-reads-content-annotator@.service
+++ b/rec-reads-content-annotator@.service
@@ -38,6 +38,9 @@ ExecStart=/bin/sh -c '\
   --env "ANNOTATING_SYSTEM=concept-suggestor" \
   --env "JAVA_OPTS=$JAVA_OPTS" \
   --env "FILTER_NOVELTIES=false" \
+  --env "GRAPHITE_HOST=graphite.ft.com" \
+  --env "GRAPHITE_PORT=2003" \
+  --env "GRAPHITE_PREFIX=coco.services.$ENV.rec-reads-content-annotator.%i" \
   up-registry.ft.com/coco/content-annotator:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'

--- a/services.yaml
+++ b/services.yaml
@@ -449,7 +449,7 @@ services:
 - name: rec-reads-content-annotator-sidekick@.service
   count: 1
 - name: rec-reads-content-annotator@.service
-  version: v44
+  version: v54
   count: 1
 - name: rec-reads-content-ingester-sidekick@.service
   count: 1
@@ -539,32 +539,32 @@ services:
 - name: v1-content-annotator-binding-service-blue-sidekick@.service
   count: 1
 - name: v1-content-annotator-binding-service-blue@.service
-  version: v53
+  version: v54
   count: 1
 - name: v1-content-annotator-binding-service-red-sidekick@.service
   count: 1
 - name: v1-content-annotator-binding-service-red@.service
-  version: v53
+  version: v54
   count: 1
 - name: v1-content-annotator-blue-sidekick@.service
   count: 1
 - name: v1-content-annotator-blue@.service
-  version: v53
+  version: v54
   count: 1
 - name: v1-content-annotator-brightcove-blue-sidekick@.service
   count: 1
 - name: v1-content-annotator-brightcove-blue@.service
-  version: v53
+  version: v54
   count: 1
 - name: v1-content-annotator-brightcove-red-sidekick@.service
   count: 1
 - name: v1-content-annotator-brightcove-red@.service
-  version: v53
+  version: v54
   count: 1
 - name: v1-content-annotator-red-sidekick@.service
   count: 1
 - name: v1-content-annotator-red@.service
-  version: v53
+  version: v54
   count: 1
 - name: v1-suggestor-sidekick@.service
   count: 2
@@ -584,12 +584,12 @@ services:
 - name: v2-content-annotator-blue-sidekick@.service
   count: 1
 - name: v2-content-annotator-blue@.service
-  version: v53
+  version: v54
   count: 1
 - name: v2-content-annotator-red-sidekick@.service
   count: 1
 - name: v2-content-annotator-red@.service
-  version: v53
+  version: v54
   count: 1
 - name: varnish@.service
   version: v0.1.6


### PR DESCRIPTION
New suggestions endpoint that we can reload annotations from cache rather than going around the whole content cycle

http://git.svc.ft.com:8080/projects/CP/repos/content-annotator/pull-requests/26/overview