### PR TITLE
Internal components mapper, changed bgColor label to backgroundColour 

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -274,7 +274,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: v0.0.6
+  version: v0.0.7
   count: 2
 - name: methode-article-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
As decided with Sarah, the internal component topper will expose the label backgroundColour label instead of bgColor.

https://github.com/Financial-Times/methode-article-internal-components-mapper/pull/6