### PR TITLE
Internal components mapper fix.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -285,7 +285,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: v0.0.7
+  version: v0.0.8
   count: 2
 - name: methode-article-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
https://github.com/Financial-Times/methode-article-internal-components-mapper/pull/7

methode-article-internal-components mapper should return 404 when the article doesn't contain internal components, instead of 422.