### PR TITLE
Fixing MDC bug

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -423,7 +423,7 @@ services:
 - name: notifications-rw-sidekick@.service
   count: 2
 - name: notifications-rw@.service
-  version: v72
+  version: v72_mdc-fix_rc1
   count: 2
   sequentialDeployment: true
 - name: organisations-rw-neo4j-blue-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -423,7 +423,7 @@ services:
 - name: notifications-rw-sidekick@.service
   count: 2
 - name: notifications-rw@.service
-  version: v72_mdc-fix_rc1
+  version: v73
   count: 2
   sequentialDeployment: true
 - name: organisations-rw-neo4j-blue-sidekick@.service


### PR DESCRIPTION
The `deferred write` log line had an incorrect MDC transaction id, which could cause confusion.