### PR TITLE
Feature/methode content collection mapper

### DIFF
--- a/methode-content-collection-mapper-sidekick@.service
+++ b/methode-content-collection-mapper-sidekick@.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Methode content collection mapper sidekick
+BindsTo=methode-content-collection-mapper@%i.service
+After=methode-content-collection-mapper@%i.service
+
+[Service]
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "\
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl set   /ft/services/$SERVICE/healthcheck     true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set   /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/categories content-publish; \
+  while [ -z $PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=^/\"$SERVICE\"-%i_); \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
+  
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/methode-content-collection-mapper/servers/%i'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=methode-content-collection-mapper@%i.service

--- a/methode-content-collection-mapper@.service
+++ b/methode-content-collection-mapper@.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Methode content collection mapper
+After=vulcan.service
+Requires=docker.service
+Wants=methode-content-collection-mapper-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+Environment="JAVA_OPTS=-Xms128m -Xmx128m -XX:+UseG1GC -server"
+
+TimeoutStartSec=0
+
+# Change killmode from "control-group" to "none" to let Docker remove
+# work correctly.
+KillMode=none
+
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c 'docker history coco/methode-story-package-mapper:$DOCKER_APP_VERSION > /dev/null 2>&1 \
+|| docker pull coco/methode-story-package-mapper:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/sh -c '\
+  /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
+  --env "JAVA_OPTS=$JAVA_OPTS" \
+  --env "VULCAN_HOST=%H:8080" \
+  coco/methode-story-package-mapper:$DOCKER_APP_VERSION'
+  
+ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=%p@*.service

--- a/services.yaml
+++ b/services.yaml
@@ -295,7 +295,7 @@ services:
 - name: methode-content-collection-mapper-sidekick@.service
   count: 2
 - name: methode-content-collection-mapper@.service
-  version: v1.0.2-rj-rc1
+  version: v1.0.2
   count: 2
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -295,7 +295,7 @@ services:
 - name: methode-content-collection-mapper-sidekick@.service
   count: 2
 - name: methode-content-collection-mapper@.service
-  version: v1.0.1-rj-rc1
+  version: v1.0.1-rj-rc2
   count: 2
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -295,7 +295,7 @@ services:
 - name: methode-content-collection-mapper-sidekick@.service
   count: 2
 - name: methode-content-collection-mapper@.service
-  version: v1.0.1-rj-rc2
+  version: v1.0.2-rj-rc1
   count: 2
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -292,6 +292,11 @@ services:
 - name: methode-article-mapper@.service
   version: v1.0.15
   count: 2
+- name: methode-content-collection-mapper-sidekick@.service
+  count: 2
+- name: methode-content-collection-mapper@.service
+  version: v1.0.1-rj-rc1
+  count: 2
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2
 - name: methode-content-placeholder-mapper@.service


### PR DESCRIPTION
New service, has 2 major versions, that merge the work of story package and content-package in to one generic service for both.

This latest version is adding support for content-package and generifies the whole service:
https://github.com/Financial-Times/methode-story-package-mapper/pull/2

P.S. We will do a clean-up PR to change github repo name from methode-story-package-mapper to methode-content-collection-mapper after this is in prod.