### PR TITLE
Content Placeholders should be saved as "Content" Notifications

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -433,7 +433,7 @@ services:
 - name: notifications-rw-sidekick@.service
   count: 2
 - name: notifications-rw@.service
-  version: v74
+  version: v75
   count: 2
   sequentialDeployment: true
 - name: organisations-rw-neo4j-blue-sidekick@.service


### PR DESCRIPTION
Re-releasing alongside the fix to PAM which is [here](https://github.com/Financial-Times/pub-service-files/pull/185).