### PR TITLE
Renamed content collection mapper repo name.

### DIFF
--- a/methode-content-collection-mapper@.service
+++ b/methode-content-collection-mapper@.service
@@ -16,14 +16,14 @@ KillMode=none
 
 ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'
 ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'
-ExecStartPre=/bin/bash -c 'docker history coco/methode-story-package-mapper:$DOCKER_APP_VERSION > /dev/null 2>&1 \
-|| docker pull coco/methode-story-package-mapper:$DOCKER_APP_VERSION'
+ExecStartPre=/bin/bash -c 'docker history coco/methode-content-collection-mapper:$DOCKER_APP_VERSION > /dev/null 2>&1 \
+|| docker pull coco/methode-content-collection-mapper:$DOCKER_APP_VERSION'
 
 ExecStart=/bin/sh -c '\
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
   --env "JAVA_OPTS=$JAVA_OPTS" \
   --env "VULCAN_HOST=%H:8080" \
-  coco/methode-story-package-mapper:$DOCKER_APP_VERSION'
+  coco/methode-content-collection-mapper:$DOCKER_APP_VERSION'
   
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'
 Restart=on-failure


### PR DESCRIPTION
Changed the docker hub repo name of methode-content-collection-mapper (from previous methode-story-package-mapper): https://hub.docker.com/r/coco/methode-content-collection-mapper/

The old one is here: https://hub.docker.com/r/coco/methode-story-package-mapper/
Both repos are currently up, I will remove the old one once this is merged to PROD: