### PR TITLE
Fix the mapper's /build-info endpoint & panic guide urls

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -365,7 +365,7 @@ services:
 - name: methode-image-binary-mapper-sidekick@.service
   count: 2
 - name: methode-image-binary-mapper@.service
-  version: v1.0.1
+  version: v1.0.2
   count: 2
 - name: methode-image-model-mapper-sidekick@.service
   count: 2
@@ -375,7 +375,7 @@ services:
 - name: methode-image-set-mapper-sidekick@.service
   count: 2
 - name: methode-image-set-mapper@.service
-  version: v9.0.1
+  version: v9.0.2
   count: 2
 - name: methode-list-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -370,7 +370,7 @@ services:
 - name: methode-image-model-mapper-sidekick@.service
   count: 2
 - name: methode-image-model-mapper@.service
-  version: v16.0.3
+  version: v16.0.4
   count: 2
 - name: methode-image-set-mapper-sidekick@.service
   count: 2
@@ -730,7 +730,7 @@ services:
 - name: wordpress-article-mapper-sidekick@.service
   count: 2
 - name: wordpress-article-mapper@.service
-  version: v1.0.9
+  version: v1.0.10
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
Same change applied to several services:
https://github.com/Financial-Times/methode-image-binary-mapper/pull/3
https://github.com/Financial-Times/methode-image-model-mapper/pull/5
https://github.com/Financial-Times/methode-image-set-mapper/pull/3
https://github.com/Financial-Times/wordpress-article-mapper/pull/14

Tested in `xp`.
