### PR TITLE
Increased concept-search-api version to v1.0.7

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -121,7 +121,7 @@ services:
 - name: concept-search-api-sidekick@.service
   count: 2
 - name: concept-search-api@.service
-  version: v1.0.5
+  version: v1.0.7
   count: 2
 - name: concept-suggestion-api-sidekick@.service
   count: 1


### PR DESCRIPTION
https://github.com/Financial-Times/concept-search-api/pull/18

- Added vendoring to the concept-search-api
- Fixed a healthcheck bug