### PR TITLE
`/enrichedcontent` not to surface `contains` and `containedIn` fields for B2B clients

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: v63.4.2-rc
+  version: v63.4.2
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: v63.4.1
+  version: v63.4.2-rc
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service


### PR DESCRIPTION
`/enrichedcontent` not to surface `contains` and `containedIn` fields for B2B clients

* https://github.com/Financial-Times/api-policy-component/pull/12

tested in rj