### PR TITLE
bumped MAM to version that supports empty body for content packages

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -250,7 +250,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: v1.0.25-rc
+  version: v1.0.28
   count: 2
 - name: methode-content-collection-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -250,7 +250,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: v1.0.24
+  version: v1.0.25-rc
   count: 2
 - name: methode-content-collection-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
https://github.com/Financial-Times/methode-article-mapper/pull/23