### PR TITLE
bumped MAICM to version with removed deprecated content fields

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -245,7 +245,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: v1.0.3-rc1
+  version: v1.0.3
   count: 2
 - name: methode-article-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -245,7 +245,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: v1.0.1
+  version: v1.0.3-rc1
   count: 2
 - name: methode-article-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
https://github.com/Financial-Times/methode-article-internal-components-mapper/pull/12