### PR TITLE
Added gtg endpoints for SIPM, MAICM and content public read services

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -122,13 +122,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v67
+  version: v70
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v67
+  version: v70
   count: 2
   sequentialDeployment: true
 - name: content-rw-neo4j-sidekick@.service
@@ -245,7 +245,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: v1.0.1
+  version: v1.0.2
   count: 2
 - name: methode-article-mapper-sidekick@.service
   count: 2
@@ -412,7 +412,7 @@ services:
 - name: synthetic-image-publication-monitor-coco-sidekick@.service
   count: 1
 - name: synthetic-image-publication-monitor-coco@.service
-  version: v36
+  version: v37
   count: 1
 - name: system-healthcheck-sidekick.service
 - name: system-healthcheck.service


### PR DESCRIPTION
Added GTG endpoints for the following services:
 - synthetic-image-publication-monitor [https://github.com/Financial-Times/coco-synthetic-image-publication-monitor/pull/17](url)
 - content-public-read-preview [http://git.svc.ft.com/projects/CP/repos/content-public-read/pull-requests/37/overview](url)
 - content-public-read [http://git.svc.ft.com/projects/CP/repos/content-public-read/pull-requests/37/overview](url)
 - methode-article-internal-components-mapper [https://github.com/Financial-Times/methode-article-internal-components-mapper/pull/11](url)