### PR TITLE
concept-suggestion-api v36 - empty bodies are treated

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -86,7 +86,7 @@ services:
 - name: concept-suggestion-api-sidekick@.service
   count: 1
 - name: concept-suggestion-api@.service
-  version: v29
+  version: v36
   count: 1
 - name: concepts-kafka-bridge-pub-prod-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -86,7 +86,7 @@ services:
 - name: concept-suggestion-api-sidekick@.service
   count: 1
 - name: concept-suggestion-api@.service
-  version: v36
+  version: v39
   count: 1
 - name: concepts-kafka-bridge-pub-prod-sidekick@.service
   count: 1


### PR DESCRIPTION
... the same way in HTTP POST as from kafka. Log warn but goes silently.

http://git.svc.ft.com/projects/CP/repos/concept-suggestion-api/pull-requests/26/overview