### PR TITLE
Added gtg endpoints for list-notifications-rw and internal-content-api

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -198,13 +198,13 @@ services:
 - name: internal-content-preview-api-sidekick@.service
   count: 2
 - name: internal-content-preview-api@.service
-  version: v1.0.11
+  version: v1.0.12
   count: 2
   sequentialDeployment: true
 - name: internal-content-api-sidekick@.service
   count: 2
 - name: internal-content-api@.service
-  version: v1.0.11
+  version: v1.0.12
   count: 2
   sequentialDeployment: true
 - name: kafka-lagcheck-sidekick@.service
@@ -231,7 +231,7 @@ services:
 - name: list-notifications-rw-sidekick@.service
   count: 2
 - name: list-notifications-rw@.service
-  version: v0.1.2
+  version: v0.1.4
   count: 2
   sequentialDeployment: true
 - name: locations-rw-neo4j-sidekick@.service


### PR DESCRIPTION
Added gtg endpoints for:
 - internal-content-api https://github.com/Financial-Times/internal-content-api/pull/13
 - internal-content-preview-api https://github.com/Financial-Times/internal-content-api/pull/13
Fixed headers for:
 - list-notifications-rw https://github.com/Financial-Times/list-notifications-rw/pull/21