### PR TITLE
Fix/type

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -251,7 +251,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: v1.0.25-rj.rc1
+  version: v1.0.29-rj.rc1
   count: 2
 - name: methode-content-collection-mapper-sidekick@.service
   count: 2
@@ -314,7 +314,7 @@ services:
 - name: notifications-rw-sidekick@.service
   count: 2
 - name: notifications-rw@.service
-  version: v81
+  version: v82-rj.rc1
   count: 2
   sequentialDeployment: true
 - name: organisations-rw-neo4j-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -122,13 +122,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v71-rj.rc1
+  version: v71
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v71-rj.rc1
+  version: v71
   count: 2
   sequentialDeployment: true
 - name: content-rw-neo4j-sidekick@.service
@@ -253,7 +253,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: v1.0.29-rj.rc1
+  version: v1.0.29
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service
@@ -317,7 +317,7 @@ services:
 - name: notifications-rw-sidekick@.service
   count: 2
 - name: notifications-rw@.service
-  version: v82-rj.rc1
+  version: v82
   count: 2
   sequentialDeployment: true
 - name: organisations-rw-neo4j-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -122,13 +122,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v68-rj.rc1
+  version: v71-rj.rc1
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v68-rj.rc1
+  version: v71-rj.rc1
   count: 2
   sequentialDeployment: true
 - name: content-rw-neo4j-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -122,13 +122,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v67
+  version: v68-rj.rc1
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v67
+  version: v68-rj.rc1
   count: 2
   sequentialDeployment: true
 - name: content-rw-neo4j-sidekick@.service
@@ -250,7 +250,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: v1.0.24
+  version: v1.0.25-rj.rc1
   count: 2
 - name: methode-content-collection-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
1. [ContentPackage support for notifications](http://git.svc.ft.com/projects/CP/repos/notifications-rw/pull-requests/71/overview)
2. Setting the specific type in backend and prepend the type hierarchy on the read side: [MAM](https://github.com/Financial-Times/methode-article-mapper/pull/24) / [CPR](http://git.svc.ft.com/projects/CP/repos/content-public-read/pull-requests/38/overview)

Tested in `rj`.

Note: ContentPackages will need to be republished right after the release, as they already have the full type saved in the backend.