### PR TITLE
Add new endpoint for public-annotations-api.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -329,7 +329,7 @@ services:
 - name: public-annotations-api-sidekick@.service
   count: 2
 - name: public-annotations-api@.service
-  version: v1.0.0
+  version: v1.0.1
   count: 2
   sequentialDeployment: true
 - name: public-brands-api-sidekick@.service


### PR DESCRIPTION
Add new endpoint for public-annotations-api `/content/{uuid}/annotations/{platformVersion}`. 
Note: the returned annotation model contains more fields than the usual /annotations one - it includes identifiers as well.

Details: https://github.com/Financial-Times/public-annotations-api/pull/16

Tested in XP.