### PR TITLE
Fix/request api urls

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -198,13 +198,13 @@ services:
 - name: internal-content-preview-api-sidekick@.service
   count: 2
 - name: internal-content-preview-api@.service
-  version: v1.0.14-rj-rc1
+  version: v1.0.14
   count: 2
   sequentialDeployment: true
 - name: internal-content-api-sidekick@.service
   count: 2
 - name: internal-content-api@.service
-  version: v1.0.14-rj-rc1
+  version: v1.0.14
   count: 2
   sequentialDeployment: true
 - name: kafka-lagcheck-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -196,13 +196,13 @@ services:
 - name: internal-content-preview-api-sidekick@.service
   count: 2
 - name: internal-content-preview-api@.service
-  version: v1.0.12-rj-rc2
+  version: v1.0.12-rj-rc3
   count: 2
   sequentialDeployment: true
 - name: internal-content-api-sidekick@.service
   count: 2
 - name: internal-content-api@.service
-  version: v1.0.12-rj-rc2
+  version: v1.0.12-rj-rc3
   count: 2
   sequentialDeployment: true
 - name: kafka-lagcheck-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -196,13 +196,13 @@ services:
 - name: internal-content-preview-api-sidekick@.service
   count: 2
 - name: internal-content-preview-api@.service
-  version: v1.0.11
+  version: v1.0.12-rj-rc1
   count: 2
   sequentialDeployment: true
 - name: internal-content-api-sidekick@.service
   count: 2
 - name: internal-content-api@.service
-  version: v1.0.11
+  version: v1.0.12-rj-rc1
   count: 2
   sequentialDeployment: true
 - name: kafka-lagcheck-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -198,13 +198,13 @@ services:
 - name: internal-content-preview-api-sidekick@.service
   count: 2
 - name: internal-content-preview-api@.service
-  version: v1.0.13
+  version: v1.0.14-rj-rc1
   count: 2
   sequentialDeployment: true
 - name: internal-content-api-sidekick@.service
   count: 2
 - name: internal-content-api@.service
-  version: v1.0.13
+  version: v1.0.14-rj-rc1
   count: 2
   sequentialDeployment: true
 - name: kafka-lagcheck-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -196,13 +196,13 @@ services:
 - name: internal-content-preview-api-sidekick@.service
   count: 2
 - name: internal-content-preview-api@.service
-  version: v1.0.12-rj-rc3
+  version: v1.0.14-rj-rc1
   count: 2
   sequentialDeployment: true
 - name: internal-content-api-sidekick@.service
   count: 2
 - name: internal-content-api@.service
-  version: v1.0.12-rj-rc3
+  version: v1.0.14-rj-rc1
   count: 2
   sequentialDeployment: true
 - name: kafka-lagcheck-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -196,13 +196,13 @@ services:
 - name: internal-content-preview-api-sidekick@.service
   count: 2
 - name: internal-content-preview-api@.service
-  version: v1.0.12-rj-rc1
+  version: v1.0.12-rj-rc2
   count: 2
   sequentialDeployment: true
 - name: internal-content-api-sidekick@.service
   count: 2
 - name: internal-content-api@.service
-  version: v1.0.12-rj-rc1
+  version: v1.0.12-rj-rc2
   count: 2
   sequentialDeployment: true
 - name: kafka-lagcheck-sidekick@.service


### PR DESCRIPTION
https://github.com/Financial-Times/internal-content-api/pull/12

Change for internal-content-api and internal-content-preview-api:
- fixed requestUrl and apiUrl to have /internalcontent in path instead of /enrichedcontent (apiUrl is not present in internal-content-preview-api)
- added uuid validation like in other endpoints (invalid uuid returns 400 http status code).