### PR TITLE
Added gtg endpoints for content-preview and wordpress-article-mapper

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -86,7 +86,7 @@ services:
 - name: concept-suggestion-api-sidekick@.service
   count: 1
 - name: concept-suggestion-api@.service
-  version: v39
+  version: v41
   count: 1
 - name: concepts-kafka-bridge-pub-prod-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -116,7 +116,7 @@ services:
 - name: content-preview-sidekick@.service
   count: 2
 - name: content-preview@.service
-  version: v1.0.6
+  version: v1.0.7
   count: 2
   sequentialDeployment: true
 - name: content-public-read-preview-sidekick@.service
@@ -192,7 +192,7 @@ services:
 - name: internal-components-preview-sidekick@.service
   count: 2
 - name: internal-components-preview@.service
-  version: v1.0.6
+  version: v1.0.7
   count: 2
   sequentialDeployment: true
 - name: internal-content-preview-api-sidekick@.service
@@ -489,7 +489,7 @@ services:
 - name: wordpress-article-mapper-sidekick@.service
   count: 2
 - name: wordpress-article-mapper@.service
-  version: v1.0.11
+  version: v1.0.12
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
Added gtg endpoints for:
 - content-preview https://github.com/Financial-Times/content-preview/pull/20
 - internal-components-preview https://github.com/Financial-Times/content-preview/pull/20
 - wordpress-article-mapper https://github.com/Financial-Times/wordpress-article-mapper/pull/13
 - concept-suggestion-api http://git.svc.ft.com/projects/CP/repos/concept-suggestion-api/pull-requests/25/overview