### PR TITLE
kafka-bridge that supports native hash pre-prod only

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -45,12 +45,12 @@ services:
 - name: cms-kafka-bridge-pub-pre-prod-uk-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-pre-prod-uk@.service
-  version: v14.1.2
+  version: 14.1.3
   count: 2
 - name: cms-kafka-bridge-pub-pre-prod-us-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-pre-prod-us@.service
-  version: v14.1.2
+  version: 14.1.3
   count: 2
 - name: cms-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
@@ -65,12 +65,12 @@ services:
 - name: cms-metadata-kafka-bridge-pub-pre-prod-uk-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-pre-prod-uk@.service
-  version: v14.1.2
+  version: 14.1.3
   count: 2
 - name: cms-metadata-kafka-bridge-pub-pre-prod-us-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-pre-prod-us@.service
-  version: v14.1.2
+  version: 14.1.3
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
@@ -111,12 +111,12 @@ services:
 - name: concepts-kafka-bridge-pub-pre-prod-uk-sidekick@.service
   count: 1
 - name: concepts-kafka-bridge-pub-pre-prod-uk@.service
-  version: v14.1.2
+  version: 14.1.3
   count: 1
 - name: concepts-kafka-bridge-pub-pre-prod-us-sidekick@.service
   count: 1
 - name: concepts-kafka-bridge-pub-pre-prod-us@.service
-  version: v14.1.2
+  version: 14.1.3
   count: 1
 - name: content-collection-ingester-neo4j-sidekick@.service
   count: 2


### PR DESCRIPTION
This PR is to deploy the bridges between `pub-pre-prod` and `pre-prod` clusters only.
The change is implemented in this PR: https://github.com/Financial-Times/coco-kafka-bridge/pull/40