### PR TITLE
Enrichedcontent should respond in a timely manner

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -154,7 +154,7 @@ services:
 - name: enriched-content-read-api-sidekick@.service
   count: 2
 - name: enriched-content-read-api@.service
-  version: v76
+  version: v77-xp-timeout-rc.1
   count: 2
   sequentialDeployment: true
 - name: financial-instruments-rw-neo4j-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -154,7 +154,7 @@ services:
 - name: enriched-content-read-api-sidekick@.service
   count: 2
 - name: enriched-content-read-api@.service
-  version: v77-xp-timeout-rc.2
+  version: v77
   count: 2
   sequentialDeployment: true
 - name: financial-instruments-rw-neo4j-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -154,7 +154,7 @@ services:
 - name: enriched-content-read-api-sidekick@.service
   count: 2
 - name: enriched-content-read-api@.service
-  version: v77-xp-timeout-rc.1
+  version: v77-xp-timeout-rc.2
   count: 2
   sequentialDeployment: true
 - name: financial-instruments-rw-neo4j-sidekick@.service


### PR DESCRIPTION
- decreased the timeouts and number of retries that enriched-content-read-api makes when accessing content-api, relations-api and annotations-api
http://git.svc.ft.com/projects/CP/repos/enriched-content-read-api/pull-requests/31/overview