### PR TITLE
Next videos embedded within Methode articles

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -253,7 +253,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.1.0-video-embedded-video-rc4
+  version: 1.1.0-video-embedded-video-rc5
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -253,7 +253,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: v1.0.30
+  version: 1.1.0-video-embedded-video-rc1
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -253,7 +253,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.1.0-video-embedded-video-rc5
+  version: 1.1.0
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -253,7 +253,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.1.0-video-embedded-video-rc3
+  version: 1.1.0-video-embedded-video-rc4
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -253,7 +253,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.1.0-video-embedded-video-rc2
+  version: 1.1.0-video-embedded-video-rc3
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -253,7 +253,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.1.0-video-embedded-video-rc1
+  version: 1.1.0-video-embedded-video-rc2
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service


### PR DESCRIPTION
Support will be provided for embedded videos within:
- videoplayer element with both ID types: UUID (from Next Video Editor) and old Brightcove (from old Methode articles)
- content element with hyperlinks to Next video

Tested on video cluster

Service PR: https://github.com/Financial-Times/methode-article-mapper/pull/26

See documentation for Methode articles embedded videos handling:
https://sites.google.com/a/ft.com/universal-publishing/documentation/story-specs/3-mar-2017-next-video-platform-work