### PR TITLE
  Wordpress Article Mapper: Support embedded videos from Next Video Editor 

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -509,7 +509,7 @@ services:
 - name: wordpress-article-mapper-sidekick@.service
   count: 2
 - name: wordpress-article-mapper@.service
-  version: v1.0.12
+  version: 1.0.13
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
- Changes to support embedded videos in WP that are published in Next Video Editor
- Documentation can be seen here:
https://docs.google.com/a/ft.com/document/d/1ioJCmasEN2unBFnr1QcGj6Cf-QE0NKtgE2YVNYL3lVM/edit?usp=sharing
- Tested in `video` cluster
- App PR (approved & merged): https://github.com/Financial-Times/wordpress-article-mapper/pull/16