### PR TITLE
Fix/next video anns mapper healthcheck last version

### DIFF
--- a/next-video-annotations-mapper@.service
+++ b/next-video-annotations-mapper@.service
@@ -18,7 +18,9 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/upp-next-video-annotatio
 ExecStart=/bin/sh -c '\
     /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
     --memory="256m" \
-    --env "APP_NAME=next-video-annotations-mapper" \
+    --env "SERVICE_NAME=next-video-annotations-mapper" \
+    --env "APP_NAME=Next Video Annotations Mapper" \
+    --env "APP_SYSTEM_CODE=up-nvam" \
     --env "APP_PORT=8080" \
     --env "PANIC_GUIDE=https://dewey.ft.com/up-nvam.html" \
     --env "Q_ADDR=http://%H:8080" \

--- a/services.yaml
+++ b/services.yaml
@@ -306,7 +306,7 @@ services:
 - name: next-video-annotations-mapper-sidekick@.service
   count: 2
 - name: next-video-annotations-mapper@.service
-  version: 1.0.0
+  version: 1.0.1-video-healthcheck-version-rc4
   count: 2
 - name: next-video-annotations-rw-neo4j-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -306,7 +306,7 @@ services:
 - name: next-video-annotations-mapper-sidekick@.service
   count: 2
 - name: next-video-annotations-mapper@.service
-  version: 1.0.1-video-healthcheck-version-rc4
+  version: 1.0.1
   count: 2
 - name: next-video-annotations-rw-neo4j-sidekick@.service
   count: 2


### PR DESCRIPTION
- Fixes for Next Video Annotations Mapper:
-- Healthcheck version updated to the last one
-- For FT packages vendoring version refer to release/tag number instead of git commit revision

- Service PR: https://github.com/Financial-Times/upp-next-video-annotations-mapper/pull/2
- Tested in video cluster
- Service version will be updated to 1.0.1 before releasing to pre-prod