### PR TITLE
Update sys-hc to version which contains pid 1 fix

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -445,7 +445,7 @@ services:
   count: 1
 - name: system-healthcheck-sidekick.service
 - name: system-healthcheck.service
-  version: 1.0.6
+  version: 1.0.7
 - name: topics-rw-neo4j-sidekick@.service
   count: 2
 - name: topics-rw-neo4j@.service


### PR DESCRIPTION
https://github.com/Financial-Times/coco-system-healthcheck/pull/43

sys-hc now has PID 1 in the container:

```
[~][14:57:43][xp][]$ fcssh 6550b6d5 docker exec -ti c0364c820669 sh -c ps
PID   USER     TIME   COMMAND
    1 root       0:00 /coco-system-healthcheck

[~][14:58:06][xp][]$ fcssh b4c41cd7 docker exec -ti 6d6e246604dc sh -c ps
PID   USER     TIME   COMMAND
    1 root       0:00 /coco-system-healthcheck

[~][14:58:22][xp][]$ fcssh ce564685 docker exec -ti a075c90e5613 sh -c ps
PID   USER     TIME   COMMAND
    1 root       0:00 /coco-system-healthcheck

[~][14:58:42][xp][]$ fcssh f064489d docker exec -ti 0a6be88ca23c sh -c ps
PID   USER     TIME   COMMAND
    1 root       0:00 /coco-system-healthcheck

[~][15:04:50][xp][]$ fcssh f33043f9 docker exec -ti 7f9dd240e31a sh -c ps
PID   USER     TIME   COMMAND
    1 root       0:00 /coco-system-healthcheck
```