### PR TITLE
Increase check period for synthetic image publishes.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -441,7 +441,7 @@ services:
 - name: synthetic-image-publication-monitor-coco-sidekick@.service
   count: 1
 - name: synthetic-image-publication-monitor-coco@.service
-  version: v37
+  version: 37.0.1-rc-ops-updatePeriodChecks
   count: 1
 - name: system-healthcheck-sidekick.service
 - name: system-healthcheck.service

--- a/services.yaml
+++ b/services.yaml
@@ -441,7 +441,7 @@ services:
 - name: synthetic-image-publication-monitor-coco-sidekick@.service
   count: 1
 - name: synthetic-image-publication-monitor-coco@.service
-  version: 37.0.1-rc-ops-improve-logging
+  version: 37.0.1
   count: 1
 - name: system-healthcheck-sidekick.service
 - name: system-healthcheck.service

--- a/services.yaml
+++ b/services.yaml
@@ -441,7 +441,7 @@ services:
 - name: synthetic-image-publication-monitor-coco-sidekick@.service
   count: 1
 - name: synthetic-image-publication-monitor-coco@.service
-  version: 37.0.1-rc-ops-updatePeriodChecks
+  version: 37.0.1-rc-ops-improve-logging
   count: 1
 - name: system-healthcheck-sidekick.service
 - name: system-healthcheck.service


### PR DESCRIPTION
See PR from [here](https://github.com/Financial-Times/coco-synthetic-image-publication-monitor/pull/18), and the [task details](https://trello.com/c/iyzTw3sx) on the OpsCop board.