### PR TITLE
Aligned version for annotations-rw services

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -461,7 +461,7 @@ services:
 - name: v1-annotations-rw-neo4j-sidekick@.service
   count: 2
 - name: v1-annotations-rw-neo4j@.service
-  version: v0.1.9
+  version: 0.2.0
   count: 2
 - name: v1-content-annotator-binding-service-sidekick@.service
   count: 2
@@ -486,7 +486,7 @@ services:
 - name: v2-annotations-rw-neo4j-sidekick@.service
   count: 2
 - name: v2-annotations-rw-neo4j@.service
-  version: v0.1.8
+  version: 0.2.0
   count: 2
 - name: v2-content-annotator-sidekick@.service
   count: 2

--- a/v1-annotations-rw-neo4j@.service
+++ b/v1-annotations-rw-neo4j@.service
@@ -20,6 +20,7 @@ ExecStart=/bin/sh -c '\
   export NEO_URL=$(/usr/bin/etcdctl get /ft/config/neo4j/read_write_url); \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --memory="256m" \
+  --env "ANNOTATION_LIFECYCLE=annotations-v1" \
   --env "PLATFORM_VERSION=v1" \
   --env "NEO_URL=$NEO_URL" \
   --env "APP_PORT=$APP_PORT" \

--- a/v2-annotations-rw-neo4j@.service
+++ b/v2-annotations-rw-neo4j@.service
@@ -20,6 +20,7 @@ ExecStart=/bin/sh -c '\
   export NEO_URL=$(/usr/bin/etcdctl get /ft/config/neo4j/read_write_url); \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $APP_PORT \
   --memory="256m" \
+  --env "ANNOTATION_LIFECYCLE=annotations-v2" \
   --env "PLATFORM_VERSION=v2" \
   --env "NEO_URL=$NEO_URL" \
   --env "APP_PORT=$APP_PORT" \


### PR DESCRIPTION
Version 0.2.0 to be used for all services which have annotations-rw as a code base: https://github.com/Financial-Times/annotations-rw-neo4j/releases/tag/0.2.0
This contains @david-smith-ft's changes as well: https://github.com/Financial-Times/annotations-rw-neo4j/pull/18

NOTE: Except **brightcove-annotations-rw-neo4j** which will be decommissioned soon