### PR TITLE
Content package title override and dummy text removal

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -264,7 +264,7 @@ services:
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2
 - name: methode-content-placeholder-mapper@.service
-  version: v0.0.8
+  version: v0.0.9-rj-cp-title-override-rc1
   count: 2
 - name: methode-image-binary-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -253,7 +253,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: v1.0.30
+  version: 1.1.1-rj-cp-override-title-rc1
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -247,13 +247,13 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: 1.0.5
+  version: 1.0.6-rj-dummy-text-removal-rc1
   count: 2
   sequentialDeployment: true
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.1.1-rj-cp-override-title-rc1
+  version: 1.1.1-rj-cp-override-title-rc2
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service
@@ -264,7 +264,7 @@ services:
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2
 - name: methode-content-placeholder-mapper@.service
-  version: v0.0.9-rj-cp-title-override-rc1
+  version: v0.0.9-rj-cp-title-override-rc2
   count: 2
 - name: methode-image-binary-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -264,7 +264,7 @@ services:
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2
 - name: methode-content-placeholder-mapper@.service
-  version: v0.0.9-rj-cp-title-override-rc2
+  version: 0.0.9-rj-cp-title-override-rc3
   count: 2
 - name: methode-image-binary-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -122,13 +122,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v74
+  version: v75-rj-cp-override-title-rc1
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v74
+  version: v75-rj-cp-override-title-rc1
   count: 2
   sequentialDeployment: true
 - name: content-rw-neo4j-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -122,13 +122,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v75-rj-cp-override-title-rc1
+  version: v75
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v75-rj-cp-override-title-rc1
+  version: v75
   count: 2
   sequentialDeployment: true
 - name: content-rw-neo4j-sidekick@.service
@@ -247,13 +247,13 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: 1.0.6-rj-dummy-text-removal-rc1
+  version: 1.0.6
   count: 2
   sequentialDeployment: true
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.1.1-rj-cp-override-title-rc2
+  version: 1.1.1
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service
@@ -264,7 +264,7 @@ services:
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2
 - name: methode-content-placeholder-mapper@.service
-  version: 0.0.9-rj-cp-title-override-rc3
+  version: 0.0.9
   count: 2
 - name: methode-image-binary-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
MAM: https://github.com/Financial-Times/methode-article-mapper/pull/27
MCPM: https://github.com/Financial-Times/methode-content-placeholder-mapper/pull/11
MAICM: https://github.com/Financial-Times/methode-article-internal-components-mapper/pull/15
CPR: http://git.svc.ft.com/projects/CP/repos/content-public-read/pull-requests/40/overview