### PR TITLE
Filtering unrelated kafka bridges from healthchecks

### DIFF
--- a/kafka-lagcheck@.service
+++ b/kafka-lagcheck@.service
@@ -16,10 +16,12 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/kafka-lagcheck:$DOCKER_A
   
 ExecStart=/bin/sh -c '\
   LAG_TOLERANCE=$(etcdctl get /ft/config/kafka-lagcheck/lag-tolerance) || LAG_TOLERANCE=30; \
+  WHITELISTED_ENVS=$(etcdctl get /ft/config/kafka-lagcheck/whitelisted-envs); \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \
     --memory="256m" \
     --env "HOST_MACHINE=%H" \
     --env "WHITELISTED_TOPICS=Concept" \
+    --env "WHITELISTED_ENVS=$WHITELISTED_ENVS" \
     --env "LAG_TOLERANCE=$LAG_TOLERANCE" \
     coco/kafka-lagcheck:$DOCKER_APP_VERSION;'
     

--- a/services.yaml
+++ b/services.yaml
@@ -210,7 +210,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: v1.0.14
+  version: 1.0.15
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1


### PR DESCRIPTION
This is meant to suppress warnings from prod kafka-lagcheck caused by consumers (kafka-bridges) from lower envs.
PR for kafka-lagcheck changes: https://github.com/Financial-Times/kafka-lagcheck/pull/3