### PR TITLE
Handle story package for videos (upp-video-content-collection-mapper)

### DIFF
--- a/next-video-content-collection-mapper-sidekick@.service
+++ b/next-video-content-collection-mapper-sidekick@.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Next Video Content Collection Mapper sidekick
+BindsTo=next-video-content-collection-mapper@%i.service
+After=next-video-content-collection-mapper@%i.service
+
+[Service]
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "\
+  export SERVICE=$(echo %p | sed 's/-sidekick//g'); \
+  etcdctl set /ft/services/$SERVICE/healthcheck true; \
+  etcdctl mkdir /ft/services/$SERVICE/servers; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/path /__health; \
+  etcdctl set /ft/healthcheck/$SERVICE-%i/categories content-publish; \
+  while [ -z $PORT ]; do \
+    sleep 5; \
+    CONTAINER_NAME=$(docker ps -q --filter=name=\"$SERVICE\"-%i_); \
+    PORT=`echo $(/usr/bin/docker port $CONTAINER_NAME 8080 | cut -d':' -f2)`; \
+  done; \
+  etcdctl set /ft/services/$SERVICE/servers/%i http://%H:$PORT;"
+
+ExecStop=-/bin/bash -c '/usr/bin/etcdctl rm /ft/services/next-video-content-collection-mapper/servers/%i'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+MachineOf=next-video-content-collection-mapper@%i.service

--- a/next-video-content-collection-mapper@.service
+++ b/next-video-content-collection-mapper@.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Next Video Content Collection Mapper
+After=vulcan.service
+Requires=docker.service
+Wants=next-video-content-collection-mapper-sidekick@%i.service
+
+[Service]
+Environment="DOCKER_APP_VERSION=latest"
+TimeoutStartSec=0
+# Change killmode from "control-group" to "none" to let Docker remove
+# work correctly.
+KillMode=none
+ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=-/bin/bash -c '/usr/bin/docker rm "$(docker ps -q --filter=name=%p-%i_)" > /dev/null 2>&1'
+ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/upp-next-video-content-collection-mapper:$DOCKER_APP_VERSION > /dev/null 2>&1 \
+  || docker pull coco/upp-next-video-content-collection-mapper:$DOCKER_APP_VERSION'
+
+ExecStart=/bin/sh -c '\
+    /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
+    --memory="256m" \
+    --env "APP_NAME=Next Video Content Collection Mapper" \
+    --env "APP_SYSTEM_CODE=upp-next-video-cc-mapper" \
+    --env "SERVICE_NAME=next-video-content-collection-mapper" \
+    --env "APP_PORT=8080" \
+    --env "Q_ADDR=http://%H:8080" \
+    --env "Q_GROUP=NextVideoContentCollectionMapper" \
+    --env "Q_READ_TOPIC=NativeCmsPublicationEvents" \
+    --env "Q_READ_QUEUE=kafka" \
+    --env "Q_WRITE_TOPIC=CmsPublicationEvents" \
+    --env "Q_WRITE_QUEUE=kafka" \
+    coco/upp-next-video-content-collection-mapper:$DOCKER_APP_VERSION;'
+ExecStop=-/bin/bash -c '/usr/bin/docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
+Restart=on-failure
+RestartSec=60
+
+[X-Fleet]
+Conflicts=next-video-content-collection-mapper@*.service

--- a/services.yaml
+++ b/services.yaml
@@ -314,6 +314,11 @@ services:
 - name: next-video-content-annotator@.service
   version: v63
   count: 2
+  name: next-video-content-collection-mapper-sidekick@.service
+  count: 2
+  name: next-video-content-collection-mapper@.service
+  version: 1.0.0
+  count: 2
 - name: next-video-mapper-sidekick@.service
   count: 2
 - name: next-video-mapper@.service

--- a/services.yaml
+++ b/services.yaml
@@ -314,9 +314,9 @@ services:
 - name: next-video-content-annotator@.service
   version: v63
   count: 2
-  name: next-video-content-collection-mapper-sidekick@.service
+- name: next-video-content-collection-mapper-sidekick@.service
   count: 2
-  name: next-video-content-collection-mapper@.service
+- name: next-video-content-collection-mapper@.service
   version: 1.0.0
   count: 2
 - name: next-video-mapper-sidekick@.service


### PR DESCRIPTION
- New service that will handle `related` videos as story package items
- Architecture diagram: see https://sites.google.com/a/ft.com/universal-publishing/documentation/story-specs/3-mar-2017-next-video-platform-work
- Release candidate: https://github.com/Financial-Times/upp-next-video-content-collection-mapper/releases/tag/1.0.0
- Tested in `video` cluster