### PR TITLE
Make mongo-configurator a simple service, and add restart condition

### DIFF
--- a/mongodb-configurator.service
+++ b/mongodb-configurator.service
@@ -9,7 +9,6 @@ TimeoutStartSec=0
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.
 KillMode=none
-Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=-/bin/bash -c "/usr/bin/docker kill "$(docker ps -q --filter=name=%p_)" > /dev/null 2>&1"
 ExecStartPre=-/bin/bash -c "/usr/bin/docker rm "$(docker ps -q --filter=name=%p_)" > /dev/null 2>&1"
@@ -44,4 +43,6 @@ ExecStart=/bin/bash -c '\
         coco/coco-mongodb-configurator:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p_)"'
+Restart=on-failure
+RestartSec=60
 


### PR DESCRIPTION
- upp2-188
- this change handles the case when the mongo configurator reads invalid data from etcd: instead of failing and stopping when it encounters and unreacheable mongo, it will fail and be restarted so it can retry