### PR TITLE
Increase mongo stop grace period

### DIFF
--- a/mongodb@.service
+++ b/mongodb@.service
@@ -24,7 +24,7 @@ ExecStart=/bin/sh -c "\
   -p $(( $MONGO_ADMIN_PORT + %i )):$MONGO_ADMIN_PORT \
   coco/coco-mongodb:$DOCKER_APP_VERSION;"
 
-ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
+ExecStop=-/bin/bash -c 'docker stop -t 30 "$(docker ps -q --filter=name=%p-%i_)"'
 Restart=on-failure
 RestartSec=60
 


### PR DESCRIPTION
- this will allow mongodb ample time to shut down gracefully before being forcefully terminated
- for more details see UPP2-198
- this change *WILL* restart the mongos