### PR TITLE
Minor content-rw-elasticsearch service fixes - version 1.0.2

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -135,7 +135,7 @@ services:
 - name: content-rw-elasticsearch-sidekick@.service
   count: 2
 - name: content-rw-elasticsearch@.service
-  version: 1.0.0
+  version: 1.0.2
   count: 2
 - name: content-rw-neo4j-sidekick@.service
   count: 2


### PR DESCRIPTION
[PR](https://github.com/Financial-Times/content-rw-elasticsearch/pull/4)

Tested in XP.