### PR TITLE
Improve content es indexer logging

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -135,7 +135,7 @@ services:
 - name: content-rw-elasticsearch-sidekick@.service
   count: 2
 - name: content-rw-elasticsearch@.service
-  version: 1.0.3-fd-fix-logging-and-uuid-utils-rc2
+  version: 1.0.3
   count: 2
 - name: content-rw-neo4j-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -135,7 +135,7 @@ services:
 - name: content-rw-elasticsearch-sidekick@.service
   count: 2
 - name: content-rw-elasticsearch@.service
-  version: 1.0.2
+  version: 1.0.3-fd-fix-logging-rc1
   count: 2
 - name: content-rw-neo4j-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -135,7 +135,7 @@ services:
 - name: content-rw-elasticsearch-sidekick@.service
   count: 2
 - name: content-rw-elasticsearch@.service
-  version: 1.0.3-fd-fix-logging-rc1
+  version: 1.0.3-fd-fix-logging-and-uuid-utils-rc2
   count: 2
 - name: content-rw-neo4j-sidekick@.service
   count: 2


### PR DESCRIPTION
Improve content-rw-elasticsearch logging + generating image uuids using the uuid-utils library.
[PR](https://github.com/Financial-Times/content-rw-elasticsearch/pull/6)

Tested in XP