### PR TITLE
ES content indexing - propagate TID

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -140,7 +140,7 @@ services:
 - name: content-rw-elasticsearch-sidekick@.service
   count: 2
 - name: content-rw-elasticsearch@.service
-  version: 1.0.3
+  version: 1.0.4
   count: 2
 - name: content-rw-neo4j-sidekick@.service
   count: 2
@@ -370,7 +370,7 @@ services:
 - name: post-publication-combiner-sidekick@.service
   count: 2
 - name: post-publication-combiner@.service
-  version: 1.0.1
+  version: 1.0.2
   count: 2
 - name: public-annotations-api-sidekick@.service
   count: 2


### PR DESCRIPTION
- Propagate TID if given as a request header for the post-publication-combiner force endpoint. [[PR]](https://github.com/Financial-Times/post-publication-combiner/pull/5)

- Overwrite the publishReference field in ES with the actual transaction id, instead of the content's publishRef value. [[PR]](https://github.com/Financial-Times/content-rw-elasticsearch/pull/7)

~ Tested in XP.