### PR TITLE
Improved kafka lagcheck to use burrow status

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -222,7 +222,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: 2.0.0.burrow-status.rc1
+  version: 2.0.1
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -222,7 +222,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: 1.0.16
+  version: 2.0.0.burrow-status.rc1
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1


### PR DESCRIPTION
Improved kafka lagcheck to use burrow status in order to determine if it should be warning for a specific consumer group.

Codebase PR: https://github.com/Financial-Times/kafka-lagcheck/pull/5