### PR TITLE
Type for videos: changed from MediaResource to Video

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -145,7 +145,7 @@ services:
 - name: content-rw-neo4j-sidekick@.service
   count: 2
 - name: content-rw-neo4j@.service
-  version: 1.0.3
+  version: 1.0.4
   count: 2
 - name: coreos-version-checker-sidekick.service
 - name: coreos-version-checker.service
@@ -265,7 +265,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.1.2
+  version: 1.1.3
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service
@@ -338,7 +338,7 @@ services:
 - name: next-video-mapper-sidekick@.service
   count: 2
 - name: next-video-mapper@.service
-  version: 1.3.1
+  version: 1.3.2
   count: 2
 - name: notifications-ingester-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -128,13 +128,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v80
+  version: v81
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v80
+  version: v81
   count: 2
   sequentialDeployment: true
 - name: content-rw-elasticsearch-sidekick@.service


### PR DESCRIPTION
Media type for videos has been changed from `MediaResource` to `Video`. The following services are affected:

- [upp-next-video-mapper ](https://github.com/Financial-Times/upp-next-video-mapper/releases/tag/1.3.2)
- [methode-article-mapper](https://github.com/Financial-Times/methode-article-mapper/releases/tag/1.1.3)
- [content-rw-neo4j](https://github.com/Financial-Times/content-rw-neo4j/releases/tag/1.0.4)
- [content-public-read](http://git.svc.ft.com:8080/projects/CP/repos/content-public-read/pull-requests/47/overview)

Tested in `video` cluster