### PR TITLE
Onward journey

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 64.2.0-rj-onward-journey-rc1
+  version: 64.2.0-rj-onward-journey-rc2
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service
@@ -265,7 +265,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.2.0-rj-onward-journey-rc2
+  version: 1.2.0-rj-onward-journey-rc3
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -265,7 +265,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.2.0-rj-onward-journey-rc1
+  version: 1.2.0-rj-onward-journey-rc2
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 64.0.0-rj-onward-journey-rc1
+  version: 64.0.0-rj-onward-journey-rc2
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 64.2.0-rj-onward-journey-rc2
+  version: 64.2.0
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service
@@ -265,7 +265,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.2.0-rj-onward-journey-rc3
+  version: 1.2.0
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 63.8.0
+  version: 64.0.0-rj-onward-journey-rc1
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -265,7 +265,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.1.3
+  version: 1.2.0-rj-onward-journey-rc1
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service


### PR DESCRIPTION
This is about onward journey being allowed on the /internalcontent and /internalcontent-preview and strip out on the other endpoints (for B2B customers).

Codebase PR: 
https://github.com/Financial-Times/api-policy-component/pull/20
https://github.com/Financial-Times/methode-article-mapper/pull/31