### PR TITLE
Image rights feature

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 63.10.0-ir-fix-expand-images-rc1
+  version: 63.10.0-ir-fix-expand-images-rc2
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 63.9.0
+  version: 63.10.0-ir-fix-expand-images-rc1
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 63.10.0-ir-fix-expand-images-rc2
+  version: 64.1.0
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 63.8.0
+  version: 63.9.0
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service
@@ -128,13 +128,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v81
+  version: v82
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v81
+  version: v82
   count: 2
   sequentialDeployment: true
 - name: content-rw-elasticsearch-sidekick@.service
@@ -286,7 +286,7 @@ services:
 - name: methode-image-model-mapper-sidekick@.service
   count: 2
 - name: methode-image-model-mapper@.service
-  version: 16.2.3
+  version: 16.3.0
   count: 2
 - name: methode-image-set-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
Fields for image rights from Methode: mapped, stored and exposed in CAPI.
Tested in `video` cluster. Services affected:

- [methode-image-model-mapper](https://github.com/Financial-Times/methode-image-model-mapper/pull/11)
- [content-public-read](http://git.svc.ft.com/projects/CP/repos/content-public-read/pull-requests/46/overview)
- api-policy-component: [this](https://github.com/Financial-Times/api-policy-component/pull/19) and [this](https://github.com/Financial-Times/api-policy-component/pull/21)