### PR TITLE
Use post url as webUrl for wordpress blogs

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 64.0.0-ops-allow-webUrls-to-pass-rc1
+  version: 64.0.0
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service
@@ -502,7 +502,7 @@ services:
 - name: wordpress-article-mapper-sidekick@.service
   count: 2
 - name: wordpress-article-mapper@.service
-  version: 1.0.15-ops-add-webUrl-rc1
+  version: 1.0.15
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -13,7 +13,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 63.8.0
+  version: 64.0.0-ops-allow-webUrls-to-pass-rc1
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service
@@ -502,7 +502,7 @@ services:
 - name: wordpress-article-mapper-sidekick@.service
   count: 2
 - name: wordpress-article-mapper@.service
-  version: 1.0.14
+  version: 1.0.15-ops-add-webUrl-rc1
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
Wordpress Article Mapper: [PR](https://github.com/Financial-Times/wordpress-article-mapper/pull/18)
Api Policy Component: [PR](https://github.com/Financial-Times/api-policy-component/pull/22)