### PR TITLE
Disable Splunk Forwarder

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -478,6 +478,7 @@ services:
   version: v0.1.6
   count: 2
 - name: splunk-forwarder.service
+  desiredState: loaded
 - name: synthetic-image-publication-monitor-coco-sidekick@.service
   count: 1
 - name: synthetic-image-publication-monitor-coco@.service


### PR DESCRIPTION
Due to Splunk Cloud license limits, this disables the Splunk Forwarder on a temporary basis for the `pre-prod` environments until we can get more permanent code changes out.