### PR TITLE
Fix date formatting to use 24 hours clock

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -107,7 +107,7 @@ services:
 - name: content-collection-unfolder-sidekick@.service
   count: 2
 - name: content-collection-unfolder@.service
-  version: 1.0.0
+  version: 1.0.2-rj-fix-date-format-rc1
   count: 2
 - name: content-ingester-neo4j-sidekick@.service
   count: 2
@@ -276,7 +276,7 @@ services:
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2
 - name: methode-content-placeholder-mapper@.service
-  version: 0.0.10
+  version: 0.0.11-rj-fix-date-format-rc1
   count: 2
 - name: methode-image-binary-mapper-sidekick@.service
   count: 2
@@ -318,7 +318,7 @@ services:
 - name: next-video-annotations-mapper-sidekick@.service
   count: 2
 - name: next-video-annotations-mapper@.service
-  version: 1.0.1
+  version: 1.0.2-rj-fix-date-format-rc1
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-rw-neo4j-sidekick@.service
@@ -336,12 +336,12 @@ services:
 - name: next-video-content-collection-mapper-sidekick@.service
   count: 2
 - name: next-video-content-collection-mapper@.service
-  version: 1.0.0
+  version: 1.0.1-rj-fix-date-format-rc1
   count: 2
 - name: next-video-mapper-sidekick@.service
   count: 2
 - name: next-video-mapper@.service
-  version: 1.3.2
+  version: 1.3.3-rj-fix-date-format-rc1
   count: 2
 - name: notifications-ingester-sidekick@.service
   count: 2


### PR DESCRIPTION
This is fixing some apps date format by replacing 12 hours clock date format with 24 hours one, as this is the standard we want to use.

Codebases PRs:
MCPM: Financial-Times/methode-content-placeholder-mapper#14
UNVM: Financial-Times/upp-next-video-mapper#8
UNVAM: Financial-Times/upp-next-video-annotations-mapper#4
UNVCCM: Financial-Times/upp-next-video-content-collection-mapper#2
CCU: Financial-Times/content-collection-unfolder#6