### PR TITLE
CPR not logging HTTP 404s as errors with stacktraces

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -128,13 +128,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v81
+  version: v83-rc1
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v81
+  version: v83-rc1
   count: 2
   sequentialDeployment: true
 - name: content-rw-elasticsearch-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -128,13 +128,13 @@ services:
 - name: content-public-read-preview-sidekick@.service
   count: 2
 - name: content-public-read-preview@.service
-  version: v83-rc1
+  version: v83
   count: 2
   sequentialDeployment: true
 - name: content-public-read-sidekick@.service
   count: 2
 - name: content-public-read@.service
-  version: v83-rc1
+  version: v83
   count: 2
   sequentialDeployment: true
 - name: content-rw-elasticsearch-sidekick@.service


### PR DESCRIPTION
Please see http://git.svc.ft.com/projects/CP/repos/content-public-read/pull-requests/48/overview

Tested in team clusters, works as expected