### PR TITLE
Image rights work for WIM for consistency

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -507,6 +507,6 @@ services:
 - name: wordpress-image-mapper-sidekick@.service
   count: 2
 - name: wordpress-image-mapper@.service
-  version: v48
+  version: v49
   count: 2
 - name: zookeeper.service


### PR DESCRIPTION
- `canBeDistributed` field set to `yes` by default as for image sets from Methode (see http://git.svc.ft.com/projects/CP/repos/wordpress-image-mapper/pull-requests/19/overview)