### PR TITLE
Logfilter reduce logging volume (blacklist health & gtg events)

### DIFF
--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -4,7 +4,7 @@ Description=Splunk forwarder
 [Service]
 
 Environment="DOCKER_FORWARDER_VERSION=v1.0.2"
-Environment="DOCKER_LOGFILTER_VERSION=1.1.3"
+Environment="DOCKER_LOGFILTER_VERSION=1.1.4-opscop-rc1"
 TimeoutStartSec=1200
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.

--- a/splunk-forwarder.service
+++ b/splunk-forwarder.service
@@ -4,7 +4,7 @@ Description=Splunk forwarder
 [Service]
 
 Environment="DOCKER_FORWARDER_VERSION=v1.0.2"
-Environment="DOCKER_LOGFILTER_VERSION=1.1.4-opscop-rc1"
+Environment="DOCKER_LOGFILTER_VERSION=1.1.4"
 TimeoutStartSec=1200
 # Change killmode from "control-group" to "none" to let Docker remove
 # work correctly.


### PR DESCRIPTION
Blacklisting `/__health` and `/__gtg` entries in coco logfilter, in order to temporary reduce the logging volume (OpsCop initiative).
App PR: https://github.com/Financial-Times/coco-logfilter/pull/34

How many events will be ignored after releasing this change?
*  `__health` ≈ 26k events/min
* `__gtg` ≈ 450 events/min
_(stats extracted for Prod, representing the total number of entries for both us + uk)_