### PR TITLE
Bugfix to concept-search-api boost param error

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -75,7 +75,7 @@ services:
 - name: concept-search-api-sidekick@.service
   count: 2
 - name: concept-search-api@.service
-  version: 1.0.24-dp-fixboost-param-errs-rc.1
+  version: 1.0.24
   count: 2
   sequentialDeployment: true
 - name: concept-suggestion-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -75,7 +75,7 @@ services:
 - name: concept-search-api-sidekick@.service
   count: 2
 - name: concept-search-api@.service
-  version: 1.0.22
+  version: 1.0.24-dp-fixboost-param-errs-rc.1
   count: 2
   sequentialDeployment: true
 - name: concept-suggestion-api-sidekick@.service


### PR DESCRIPTION
Upgrade of concept search api after this bugfix:
https://github.com/Financial-Times/concept-search-api/pull/36