### PR TITLE
Added different severity levels for coreos versions

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -149,7 +149,7 @@ services:
   count: 2
 - name: coreos-version-checker-sidekick.service
 - name: coreos-version-checker.service
-  version: v1.0.0
+  version: 1.0.4
 - name: diamond.service
   version: v1.1.0
 - name: document-store-api-sidekick@.service


### PR DESCRIPTION
Checks various CVE security levels for a new release, and alerts differently based on them
PR: https://github.com/Financial-Times/coreos-version-checker/pull/3