### PR TITLE
Release for Public Read APIs to support new concordance model

### DIFF
--- a/public-annotations-api@.service
+++ b/public-annotations-api@.service
@@ -26,7 +26,8 @@ ExecStart=/bin/sh -c '\
   -e "GRAPHITE_PREFIX=coco.services.$ENV.public-annotations-api.%i" \
   -e "LOG_METRICS=false" \
   -e "CACHE_DURATION=30s" \
-  coco/public-annotations-api:$DOCKER_APP_VERSION;'
+  -e "LOG_LEVEL=$(/usr/bin/etcdctl get /ft/config/public-annotations-api/logLevel)" \
+coco/public-annotations-api:$DOCKER_APP_VERSION;'
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
 Restart=on-failure
 RestartSec=60

--- a/public-concordances-api@.service
+++ b/public-concordances-api@.service
@@ -17,16 +17,18 @@ ExecStartPre=/bin/bash -c '/usr/bin/docker history coco/public-concordances-api:
 ExecStart=/bin/sh -c '\
   export APP_PORT=8080; \
   export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
-  export NEO_URL=$(/usr/bin/etcdctl get /ft/config/neo4j/read_only_url); \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) \
   --memory="256m" \
   -p $APP_PORT \
-  -e "NEO_URL=$NEO_URL" \
+  -e "NEO_URL=$(/usr/bin/etcdctl get /ft/config/neo4j/read_only_url)" \
   -e "APP_PORT=$APP_PORT" \
   -e "GRAPHITE_ADDRESS=graphite.ft.com:2003" \
   -e "GRAPHITE_PREFIX=coco.services.$ENV.public-concordances-api.%i" \
   -e "LOG_METRICS=false" \
   -e "CACHE_DURATION=10m" \
+  -e "LOG_LEVEL=$(/usr/bin/etcdctl get /ft/config/public-concordances-api/log_level)" \
+  -e "HEALTHCHECK_INTERVAL=$(/usr/bin/etcdctl get /ft/config/public-concordances-api/healthcheck_interval)" \
+  -e "BATCH_SIZE=$(/usr/bin/etcdctl get /ft/config/public-concordances-api/batch_size)" \
   coco/public-concordances-api:$DOCKER_APP_VERSION;'
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p-%i_)"'
 Restart=on-failure

--- a/services.yaml
+++ b/services.yaml
@@ -396,7 +396,7 @@ services:
 - name: public-concordances-api-sidekick@.service
   count: 2
 - name: public-concordances-api@.service
-  version: async-healthcheck
+  version: 1.1.0
   count: 2
   sequentialDeployment: true
 - name: public-content-by-concept-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -384,7 +384,7 @@ services:
 - name: public-annotations-api-sidekick@.service
   count: 2
 - name: public-annotations-api@.service
-  version: 1.2.0
+  version: 1.3.0
   count: 2
   sequentialDeployment: true
 - name: public-brands-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -396,7 +396,7 @@ services:
 - name: public-concordances-api-sidekick@.service
   count: 2
 - name: public-concordances-api@.service
-  version: 1.0.1
+  version: async-healthcheck
   count: 2
   sequentialDeployment: true
 - name: public-content-by-concept-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -390,19 +390,19 @@ services:
 - name: public-brands-api-sidekick@.service
   count: 2
 - name: public-brands-api@.service
-  version: v1.0.0
+  version: 1.1.0
   count: 2
   sequentialDeployment: true
 - name: public-concordances-api-sidekick@.service
   count: 2
 - name: public-concordances-api@.service
-  version: v0.2.0
+  version: 1.0.0
   count: 2
   sequentialDeployment: true
 - name: public-content-by-concept-api-sidekick@.service
   count: 2
 - name: public-content-by-concept-api@.service
-  version: 1.1.0
+  version: 1.2.0
   count: 2
   sequentialDeployment: true
 - name: public-organisations-api-sidekick@.service
@@ -426,7 +426,7 @@ services:
 - name: public-things-api-sidekick@.service
   count: 2
 - name: public-things-api@.service
-  version: 1.2.0
+  version: 1.3.0
   count: 2
   sequentialDeployment: true
 - name: rec-reads-content-annotator-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -384,7 +384,7 @@ services:
 - name: public-annotations-api-sidekick@.service
   count: 2
 - name: public-annotations-api@.service
-  version: 1.3.0
+  version: 1.4.0
   count: 2
   sequentialDeployment: true
 - name: public-brands-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -390,7 +390,7 @@ services:
 - name: public-brands-api-sidekick@.service
   count: 2
 - name: public-brands-api@.service
-  version: 1.1.0
+  version: v1.0.0
   count: 2
   sequentialDeployment: true
 - name: public-concordances-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -396,7 +396,7 @@ services:
 - name: public-concordances-api-sidekick@.service
   count: 2
 - name: public-concordances-api@.service
-  version: 1.0.0
+  version: 1.0.1
   count: 2
   sequentialDeployment: true
 - name: public-content-by-concept-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -390,7 +390,7 @@ services:
 - name: public-brands-api-sidekick@.service
   count: 2
 - name: public-brands-api@.service
-  version: v1.0.0
+  version: 2.0.0
   count: 2
   sequentialDeployment: true
 - name: public-concordances-api-sidekick@.service


### PR DESCRIPTION
This release is to support the new concordance model that we are initially using for managing curated brands within smartlogic

1. Content-By-Concept: https://github.com/Financial-Times/public-content-by-concept-api/pull/10
2. Annotations API: TO BE DONE
3. Things API: https://github.com/Financial-Times/public-things-api/pull/6
4. Concordances API: https://github.com/Financial-Times/public-concordances-api/pull/12
4. Brands API: https://github.com/Financial-Times/public-brands-api/pull/12