### PR TITLE
Release version for in-article layout component.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -272,7 +272,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: 1.0.6
+  version: 1.0.7
   count: 2
   sequentialDeployment: true
 - name: methode-article-mapper-sidekick@.service


### PR DESCRIPTION
This adds the in article layout component (along with in-article recommended component which is in MAM now, and will be reverted) and all the MAM body processing, in order to have the body duplicated for internal components flow.

Codebase PR: https://github.com/Financial-Times/methode-article-internal-components-mapper/pull/16