### PR TITLE
Notifications push - remove Kafka proxy

### DIFF
--- a/new-notifications-push@.service
+++ b/new-notifications-push@.service
@@ -20,13 +20,11 @@ ExecStart=/bin/sh -c '\
    export API_BASE_URL="http://"$(/usr/bin/etcdctl get /ft/config/api_host); \
    /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $NOTIFICATIONS_PUSH_PORT:8080 \
       --memory="256m" \
-      --env="QUEUE_PROXY_ADDRS=http://%H:8080" \
+      --env="KAFKA_ADDRS=$(/usr/bin/etcdctl get /ft/config/zookeeper/ip):$(/usr/bin/etcdctl get /ft/config/zookeeper/port)" \
       --env="GROUP_ID=$GROUP_ID" \
       --env="TOPIC=PostPublicationEvents" \
       --env="NOTIFICATIONS_DELAY=$(/usr/bin/etcdctl get /ft/config/cache-max-age)" \
-      --env="QUEUE_HOST=kafka" \
       --env="API_BASE_URL=$API_BASE_URL" \
-      --env="CONSUMER_BACKOFF=2" \
       --env="NOTIFICATIONS_RESOURCE=content" \
       --env="WHITELIST=^http://(methode|wordpress|content)-(article|collection)-(transformer|mapper|unfolder)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content)/[\\w-]+.*$" \
       coco/notifications-push:$DOCKER_APP_VERSION;'

--- a/services.yaml
+++ b/services.yaml
@@ -318,7 +318,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.1.0
+  version: 3.3.0
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service


### PR DESCRIPTION
Notifications Push service will be able to connect directly to Kafka, without using Kafka Proxy.
- App changes: https://github.com/Financial-Times/notifications-push/pull/46
- Tested in `video` cluster