### PR TITLE
Updated list-notifications-push to use apiKeys

### DIFF
--- a/list-notifications-push@.service
+++ b/list-notifications-push@.service
@@ -21,13 +21,11 @@ ExecStart=/bin/sh -c '\
    /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p $LIST_NOTIFICATIONS_PUSH_PORT:8080 \
       --memory="256m" \
       --env="NOTIFICATIONS_RESOURCE=lists" \
-      --env="QUEUE_PROXY_ADDRS=http://%H:8080" \
+      --env="KAFKA_ADDRS=$(/usr/bin/etcdctl get /ft/config/zookeeper/ip):$(/usr/bin/etcdctl get /ft/config/zookeeper/port)" \
       --env="GROUP_ID=$GROUP_ID" \
       --env="TOPIC=PostPublicationEvents" \
       --env="NOTIFICATIONS_DELAY=$(/usr/bin/etcdctl get /ft/config/cache-max-age)" \
-      --env="QUEUE_HOST=kafka" \
       --env="API_BASE_URL=$API_BASE_URL" \
-      --env="CONSUMER_BACKOFF=2" \
       --env="WHITELIST=^http://.*-list-mapper\\.svc\\.ft\\.com(:\\d{2,5})?/lists/[\\w-]+.*$" \
       coco/notifications-push:$DOCKER_APP_VERSION;'
 

--- a/services.yaml
+++ b/services.yaml
@@ -251,7 +251,7 @@ services:
 - name: list-notifications-push-sidekick@.service
   count: 2
 - name: list-notifications-push@.service
-  version: 3.2.0
+  version: 3.3.1
   count: 2
   sequentialDeployment: true
 - name: list-notifications-rw-sidekick@.service


### PR DESCRIPTION
changes:
- https://github.com/Financial-Times/notifications-push/pull/46 : Notifications Push service will be able to connect directly to Kafka, without using Kafka Proxy.
- https://github.com/Financial-Times/notifications-push/pull/45 Updated list-notifications-push to use apiKeys

**Note**: this should be released only after https://github.com/Financial-Times/pub-service-files/pull/290 is released. Also clients should already be using apiKeys when this change is released to prod
