### PR TITLE
Adding Title and Scoop fields to Notifications Push

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -337,7 +337,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.3.0
+  version: 3.4.0
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service


### PR DESCRIPTION
- Changing `new-notifications-push` to contain Title and Scoop fields in notifications body
- App changes: https://github.com/Financial-Times/notifications-push/commit/989fc921eeadb9a082ab611931cdf9f432a276b7
- Tested in `video` cluster