### PR TITLE
Use GLB address for load-replicator

### DIFF
--- a/load-replicator@.service
+++ b/load-replicator@.service
@@ -17,6 +17,7 @@ ExecStart=/bin/sh -c '\
   ENDPOINT_RATE_PAIRS=$(/usr/bin/etcdctl get /ft/config/load-replicator/endpoint-rate-pairs) || ENDPOINT_RATE_PAIRS="things:1;enrichedcontent:3"; \
   AUTHORIZATION=$(/usr/bin/etcdctl get /ft/config/load-replicator/authorization); \
   NOTIFICATIONS_DATE=$(/usr/bin/etcdctl get /ft/config/load-replicator/notifications); \
+  #ENVIRONMENT=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
   ENVIRONMENT=pre-prod; \
   DURATION=$(/usr/bin/etcdctl get /ft/config/load-replicator/duration) || DURATION=0; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \

--- a/load-replicator@.service
+++ b/load-replicator@.service
@@ -17,7 +17,7 @@ ExecStart=/bin/sh -c '\
   ENDPOINT_RATE_PAIRS=$(/usr/bin/etcdctl get /ft/config/load-replicator/endpoint-rate-pairs) || ENDPOINT_RATE_PAIRS="things:1;enrichedcontent:3"; \
   AUTHORIZATION=$(/usr/bin/etcdctl get /ft/config/load-replicator/authorization); \
   NOTIFICATIONS_DATE=$(/usr/bin/etcdctl get /ft/config/load-replicator/notifications); \
-  ENVIRONMENT=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
+  ENVIRONMENT=pre-prod; \
   DURATION=$(/usr/bin/etcdctl get /ft/config/load-replicator/duration) || DURATION=0; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \
   --env "ENDPOINT_RATE_PAIRS=$ENDPOINT_RATE_PAIRS" \


### PR DESCRIPTION
Currently load-replicator sends traffic to the cluster address (eg, `pre-prod-uk-up.ft.com`), which doesn't simulate failovers correctly.

This change sends all load-replicator traffic via the GLB `pre-prod-up.ft.com` address.