### PR TITLE
Removing comment, deployer / service file doesn't like it

### DIFF
--- a/load-replicator@.service
+++ b/load-replicator@.service
@@ -17,7 +17,6 @@ ExecStart=/bin/sh -c '\
   ENDPOINT_RATE_PAIRS=$(/usr/bin/etcdctl get /ft/config/load-replicator/endpoint-rate-pairs) || ENDPOINT_RATE_PAIRS="things:1;enrichedcontent:3"; \
   AUTHORIZATION=$(/usr/bin/etcdctl get /ft/config/load-replicator/authorization); \
   NOTIFICATIONS_DATE=$(/usr/bin/etcdctl get /ft/config/load-replicator/notifications); \
-  #ENVIRONMENT=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
   ENVIRONMENT=pre-prod; \
   DURATION=$(/usr/bin/etcdctl get /ft/config/load-replicator/duration) || DURATION=0; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 \


### PR DESCRIPTION
Because it's one long single line that starts up the service, I think it just accidentally comments out half of the startup command.  