### PR TITLE
Summary component and ft-content

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -278,7 +278,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: 1.2.0
+  version: 1.4.0-rj-summary-rc1
   count: 2
   sequentialDeployment: true
 - name: methode-article-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -278,7 +278,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: 1.4.0-rj-summary-rc1
+  version: 1.4.0
   count: 2
   sequentialDeployment: true
 - name: methode-article-mapper-sidekick@.service


### PR DESCRIPTION
* https://github.com/Financial-Times/methode-article-internal-components-mapper/pull/22
* https://github.com/Financial-Times/methode-article-internal-components-mapper/pull/21

## _Summary_ task

Mapping the new in-article component called summary that servers for summarizing the key points of an article.

The model in short:

```json
{
  "bodyXML": "<body><p>Some text here</p></body>",
  "summary": {
    "bodyXML": "<body><p>Some other text here</p></body>"
  },
}
```

[RJ trello card](https://trello.com/c/Thw5ZbAr/471-summary-component)

## _Recommended_ task

Transforming `<a>` tags into `<ft-content>` the correct way, setting its `type` attribute to correct FT types `Content`, `Article`, etc. Previously it was just hardcoded to `Article`.

[RJ trello card](https://trello.com/c/Gz57WuTV/124-rework-xml-tags-from-recommended)
