### PR TITLE
Allow push clients to specify type, default to 'only articles'

### DIFF
--- a/new-notifications-push@.service
+++ b/new-notifications-push@.service
@@ -26,7 +26,7 @@ ExecStart=/bin/sh -c '\
       --env="NOTIFICATIONS_DELAY=$(/usr/bin/etcdctl get /ft/config/cache-max-age)" \
       --env="API_BASE_URL=$API_BASE_URL" \
       --env="NOTIFICATIONS_RESOURCE=content" \
-      --env="WHITELIST=^http://(methode|wordpress|content)-(article|collection)-(transformer|mapper|unfolder)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content)/[\\w-]+.*$" \
+      --env="WHITELIST=^http://(methode|wordpress|content)-(article|collection|content-placeholder)-(transformer|mapper|unfolder)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content)/[\\w-]+.*$" \
       coco/notifications-push:$DOCKER_APP_VERSION;'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'

--- a/services.yaml
+++ b/services.yaml
@@ -337,7 +337,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.4.1
+  version: 3.5.0-rc1
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -337,7 +337,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.5.0
+  version: 3.5.1-upp-xtrm-content-type-rc-1
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -337,7 +337,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.5.1-upp-xtrm-content-type-rc-1
+  version: 3.5.1-upp-xtrm-content-type-rc2
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -337,7 +337,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.5.0-rc1
+  version: 3.5.0-rc2
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -337,7 +337,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.5.0-rc2
+  version: 3.5.0-rc3
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -337,7 +337,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.5.0-rc3
+  version: 3.5.0
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -337,7 +337,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.5.1-upp-xtrm-content-type-rc3
+  version: 3.5.1
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -337,7 +337,7 @@ services:
 - name: new-notifications-push-sidekick@.service
   count: 2
 - name: new-notifications-push@.service
-  version: 3.5.1-upp-xtrm-content-type-rc2
+  version: 3.5.1-upp-xtrm-content-type-rc3
   count: 2
   sequentialDeployment: true
 - name: next-video-annotations-mapper-sidekick@.service


### PR DESCRIPTION
These changes will affect **_new-notifications-push_** service. Clients can filter the content adding a request param for content type (e.g. https://api.ft.com/content/notifications-push?type=article)

- If the type is not specified, the filter will be set to `type=Article`
- Clients can specify `type=All` that will return all supported notifications, including CPHs.
- `DELETE` notifications will be always sent to the clients, because their payload is empty (in Kafka) and we cannot extract the type
- If the client specifies an invalid type, a client error is returned

- App changes: https://github.com/Financial-Times/notifications-push/pull/50 && https://github.com/Financial-Times/notifications-push/pull/51