### PR TITLE
able to retrieve items by HTTP POST including an ["array", "of", "uuids"]

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -173,7 +173,7 @@ services:
 - name: document-store-api-sidekick@.service
   count: 2
 - name: document-store-api@.service
-  version: 1.0.5-rj-multiuuid-rc1
+  version: 1.0.6
   count: 2
   sequentialDeployment: true
 - name: elb-dns-registrator.service

--- a/services.yaml
+++ b/services.yaml
@@ -173,7 +173,7 @@ services:
 - name: document-store-api-sidekick@.service
   count: 2
 - name: document-store-api@.service
-  version: 1.0.4
+  version: 1.0.5
   count: 2
   sequentialDeployment: true
 - name: elb-dns-registrator.service

--- a/services.yaml
+++ b/services.yaml
@@ -173,7 +173,7 @@ services:
 - name: document-store-api-sidekick@.service
   count: 2
 - name: document-store-api@.service
-  version: 1.0.5
+  version: 1.0.5-rj-multiuuid-rc1
   count: 2
   sequentialDeployment: true
 - name: elb-dns-registrator.service

--- a/services.yaml
+++ b/services.yaml
@@ -173,7 +173,7 @@ services:
 - name: document-store-api-sidekick@.service
   count: 2
 - name: document-store-api@.service
-  version: 1.0.3-getmultiplebypost-rc1
+  version: 1.0.4
   count: 2
   sequentialDeployment: true
 - name: elb-dns-registrator.service

--- a/services.yaml
+++ b/services.yaml
@@ -173,7 +173,7 @@ services:
 - name: document-store-api-sidekick@.service
   count: 2
 - name: document-store-api@.service
-  version: 1.0.2
+  version: 1.0.3-getmultiplebypost-rc1
   count: 2
   sequentialDeployment: true
 - name: elb-dns-registrator.service


### PR DESCRIPTION
https://github.com/Financial-Times/document-store-api/pull/5

contains also k8s helm migration
https://github.com/Financial-Times/document-store-api/pull/3

document-store-api:1.0.3-getmultiplebypost-rc1 - able to retrieve items by HTTP POST including an ["array", "of", "uuids"]