### PR TITLE
Public Annotations API - Fix brand duplication

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -391,7 +391,7 @@ services:
 - name: public-annotations-api-sidekick@.service
   count: 2
 - name: public-annotations-api@.service
-  version: 1.4.5
+  version: fix_brand-duplication
   count: 2
   sequentialDeployment: true
 - name: public-brands-api-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -391,7 +391,7 @@ services:
 - name: public-annotations-api-sidekick@.service
   count: 2
 - name: public-annotations-api@.service
-  version: fix_brand-duplication
+  version: 1.5.0
   count: 2
   sequentialDeployment: true
 - name: public-brands-api-sidekick@.service


### PR DESCRIPTION
Concorded brands were being duplicated because the query got confused when looking for parents.
https://github.com/Financial-Times/public-annotations-api/pull/29