### PR TITLE
Fix GTG endpoint

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -19,7 +19,7 @@ services:
 - name: annotations-rw-neo4j-sidekick@.service
   count: 2
 - name: annotations-rw-neo4j@.service
-  version: 1.1.1-xp-gtg-fix-rc1
+  version: 1.1.1
   count: 2
   sequentialDeployment: true
 - name: api-policy-component-sidekick@.service
@@ -464,7 +464,7 @@ services:
 - name: suggestions-rw-neo4j-sidekick@.service
   count: 2
 - name: suggestions-rw-neo4j@.service
-  version: 1.1.1-xp-gtg-fix-rc1
+  version: 1.1.1
   count: 2
 - name: synthetic-image-publication-monitor-coco-sidekick@.service
   count: 1

--- a/services.yaml
+++ b/services.yaml
@@ -19,7 +19,7 @@ services:
 - name: annotations-rw-neo4j-sidekick@.service
   count: 2
 - name: annotations-rw-neo4j@.service
-  version: 1.1.0
+  version: 1.1.1-xp-gtg-fix-rc1
   count: 2
   sequentialDeployment: true
 - name: api-policy-component-sidekick@.service
@@ -464,7 +464,7 @@ services:
 - name: suggestions-rw-neo4j-sidekick@.service
   count: 2
 - name: suggestions-rw-neo4j@.service
-  version: 1.1.0
+  version: 1.1.1-xp-gtg-fix-rc1
   count: 2
 - name: synthetic-image-publication-monitor-coco-sidekick@.service
   count: 1


### PR DESCRIPTION
annotations-rw-neo4j GTG endpoint was throwing a nil pointer dereference error because the consumer was not initialized.
https://github.com/Financial-Times/annotations-rw-neo4j/pull/30