### PR TITLE
Add k8s bridge versions - without host header routing.

### DIFF
--- a/cms-kafka-bridge-pub-prod-uk@.service
+++ b/cms-kafka-bridge-pub-prod-uk@.service
@@ -27,8 +27,7 @@ ExecStart=/bin/sh -c '\
   --env "CONSUMER_AUTOCOMMIT_ENABLE=false" \
   --env "AUTHORIZATION_KEY=$AUTHORIZATION_KEY" \
   --env "TOPIC=NativeCmsPublicationEvents" \
-  --env "PRODUCER_HOST=http://%H:8080" \
-  --env "PRODUCER_HOST_HEADER=cms-notifier" \
+  --env "PRODUCER_ADDRESS=http://%H:8080/__cms-notifier" \
   --env "PRODUCER_TYPE=plainHTTP" \
   coco/coco-kafka-bridge:$DOCKER_APP_VERSION;'
 

--- a/cms-kafka-bridge-pub-prod-us@.service
+++ b/cms-kafka-bridge-pub-prod-us@.service
@@ -27,8 +27,7 @@ ExecStart=/bin/sh -c '\
   --env "CONSUMER_AUTOCOMMIT_ENABLE=false" \
   --env "AUTHORIZATION_KEY=$AUTHORIZATION_KEY" \
   --env "TOPIC=NativeCmsPublicationEvents" \
-  --env "PRODUCER_HOST=http://%H:8080" \
-  --env "PRODUCER_HOST_HEADER=cms-notifier" \
+  --env "PRODUCER_ADDRESS=http://%H:8080/__cms-notifier" \
   --env "PRODUCER_TYPE=plainHTTP" \
   coco/coco-kafka-bridge:$DOCKER_APP_VERSION;'
 

--- a/cms-metadata-kafka-bridge-pub-prod-uk@.service
+++ b/cms-metadata-kafka-bridge-pub-prod-uk@.service
@@ -27,8 +27,7 @@ ExecStart=/bin/sh -c '\
   --env "CONSUMER_AUTOCOMMIT_ENABLE=true" \
   --env "AUTHORIZATION_KEY=$AUTHORIZATION_KEY" \
   --env "TOPIC=NativeCmsMetadataPublicationEvents" \
-  --env "PRODUCER_HOST=http://%H:8080" \
-  --env "PRODUCER_HOST_HEADER=kafka" \
+  --env "PRODUCER_ADDRESS=http://%H:8080/__kafka-rest-proxy" \
   --env "PRODUCER_TYPE=proxy" \
   coco/coco-kafka-bridge:$DOCKER_APP_VERSION;'
 

--- a/cms-metadata-kafka-bridge-pub-prod-us@.service
+++ b/cms-metadata-kafka-bridge-pub-prod-us@.service
@@ -27,8 +27,7 @@ ExecStart=/bin/sh -c '\
   --env "CONSUMER_AUTOCOMMIT_ENABLE=true" \
   --env "AUTHORIZATION_KEY=$AUTHORIZATION_KEY" \
   --env "TOPIC=NativeCmsMetadataPublicationEvents" \
-  --env "PRODUCER_HOST=http://%H:8080" \
-  --env "PRODUCER_HOST_HEADER=kafka" \
+  --env "PRODUCER_ADDRESS=http://%H:8080/__kafka-rest-proxy" \
   --env "PRODUCER_TYPE=proxy" \
   coco/coco-kafka-bridge:$DOCKER_APP_VERSION;'
 

--- a/concepts-kafka-bridge-pub-prod@.service
+++ b/concepts-kafka-bridge-pub-prod@.service
@@ -26,8 +26,7 @@ ExecStart=/bin/sh -c '\
   --env "CONSUMER_AUTOCOMMIT_ENABLE=true" \
   --env "AUTHORIZATION_KEY=$AUTHORIZATION_KEY" \
   --env "TOPIC=Concept" \
-  --env "PRODUCER_HOST=http://%H:8080" \
-  --env "PRODUCER_HOST_HEADER=kafka" \
+  --env "PRODUCER_ADDRESS=http://%H:8080/__kafka-rest-proxy" \
   --env "PRODUCER_TYPE=proxy" \
   coco/coco-kafka-bridge:$DOCKER_APP_VERSION;'
 

--- a/services.yaml
+++ b/services.yaml
@@ -105,7 +105,6 @@ services:
 - name: concepts-kafka-bridge-pub-prod@.service
   version: 15.0.0
   count: 1
-  sequentialDeployment: true
 - name: concepts-rw-neo4j-sidekick@.service
   count: 2
 - name: concepts-rw-neo4j@.service

--- a/services.yaml
+++ b/services.yaml
@@ -49,21 +49,25 @@ services:
 - name: cms-kafka-bridge-pub-prod-uk@.service
   version: 15.0.0
   count: 2
+  sequentialDeployment: true
 - name: cms-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod-us@.service
   version: 15.0.0
   count: 2
+  sequentialDeployment: true
 - name: cms-metadata-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-uk@.service
   version: 15.0.0
   count: 2
+  sequentialDeployment: true
 - name: cms-metadata-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-us@.service
   version: 15.0.0
   count: 2
+  sequentialDeployment: true
 - name: cms-notifier-sidekick@.service
   count: 1
 - name: cms-notifier@.service
@@ -101,6 +105,7 @@ services:
 - name: concepts-kafka-bridge-pub-prod@.service
   version: 15.0.0
   count: 1
+  sequentialDeployment: true
 - name: concepts-rw-neo4j-sidekick@.service
   count: 2
 - name: concepts-rw-neo4j@.service

--- a/services.yaml
+++ b/services.yaml
@@ -47,22 +47,22 @@ services:
 - name: cms-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod-uk@.service
-  version: 15.0.0-helm-rc0
+  version: 15.0.0
   count: 2
 - name: cms-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod-us@.service
-  version: 15.0.0-helm-rc0
+  version: 15.0.0
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-uk@.service
-  version: 15.0.0-helm-rc0
+  version: 15.0.0
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-us@.service
-  version: 15.0.0-helm-rc0
+  version: 15.0.0
   count: 2
 - name: cms-notifier-sidekick@.service
   count: 1
@@ -99,7 +99,7 @@ services:
 - name: concepts-kafka-bridge-pub-prod-sidekick@.service
   count: 1
 - name: concepts-kafka-bridge-pub-prod@.service
-  version: 15.0.0-helm-rc0
+  version: 15.0.0
   count: 1
 - name: concepts-rw-neo4j-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -47,22 +47,22 @@ services:
 - name: cms-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod-uk@.service
-  version: 14.2.0
+  version: 15.0.0-helm-rc0
   count: 2
 - name: cms-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod-us@.service
-  version: 14.2.0
+  version: 15.0.0-helm-rc0
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-uk@.service
-  version: 14.2.0
+  version: 15.0.0-helm-rc0
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-us@.service
-  version: 14.2.0
+  version: 15.0.0-helm-rc0
   count: 2
 - name: cms-notifier-sidekick@.service
   count: 1
@@ -99,7 +99,7 @@ services:
 - name: concepts-kafka-bridge-pub-prod-sidekick@.service
   count: 1
 - name: concepts-kafka-bridge-pub-prod@.service
-  version: 14.2.0
+  version: 15.0.0-helm-rc0
   count: 1
 - name: concepts-rw-neo4j-sidekick@.service
   count: 2


### PR DESCRIPTION
Will need to be updated with the final tagged version (after merging [this PR](https://github.com/Financial-Times/coco-kafka-bridge/pull/44)).