### PR TITLE
Bring cms-notifier in sync with k8s and pub cluster

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -71,7 +71,7 @@ services:
 - name: cms-notifier-sidekick@.service
   count: 1
 - name: cms-notifier@.service
-  version: v39
+  version: 1.55.2
   count: 1
 - name: concept-ingester-sidekick@.service
   count: 2


### PR DESCRIPTION
- bring version in sync with Kubernetes - update is from an old version but 1.55.1 was running in the pub cluster, for some reason this wasn't updated when the codebase changed, might need a closer look