### PR TITLE
Update wim to latest version, with helm integration fix

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -502,6 +502,6 @@ services:
 - name: wordpress-image-mapper-sidekick@.service
   count: 2
 - name: wordpress-image-mapper@.service
-  version: 0.55.0
+  version: 0.56.0
   count: 2
 - name: zookeeper.service


### PR DESCRIPTION
- helm config fix https://github.com/Financial-Times/wordpress-image-mapper/pull/3
- https://github.com/Financial-Times/wordpress-image-mapper/compare/0.55.0...0.56.0