### PR TITLE
Update next-video-*-mappers to latest versions with helm integration

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -336,18 +336,18 @@ services:
 - name: next-video-annotations-mapper-sidekick@.service
   count: 2
 - name: next-video-annotations-mapper@.service
-  version: 1.1.1
+  version: 1.3.0
   count: 2
   sequentialDeployment: true
 - name: next-video-content-collection-mapper-sidekick@.service
   count: 2
 - name: next-video-content-collection-mapper@.service
-  version: 1.1.0
+  version: 1.3.0
   count: 2
 - name: next-video-mapper-sidekick@.service
   count: 2
 - name: next-video-mapper@.service
-  version: 1.3.3
+  version: 1.5.0
   count: 2
 - name: notifications-ingester-sidekick@.service
   count: 2


### PR DESCRIPTION
No code changes, only helm integration:

- https://github.com/Financial-Times/upp-next-video-mapper/compare/1.3.3...1.5.0
- https://github.com/Financial-Times/upp-next-video-mapper/pull/11

- https://github.com/Financial-Times/upp-next-video-annotations-mapper/compare/1.1.1...1.3.0
- https://github.com/Financial-Times/upp-next-video-annotations-mapper/pull/7

- https://github.com/Financial-Times/upp-next-video-content-collection-mapper/compare/1.1.0...1.3.0
- https://github.com/Financial-Times/upp-next-video-content-collection-mapper/pull/5