### PR TITLE
methode-article-mapper:1.6.1 - Find the right git tag while building.

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -278,7 +278,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.6.0
+  version: 1.6.1
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service


### PR DESCRIPTION
https://github.com/Financial-Times/methode-article-mapper/pull/39