### PR TITLE
Feature/api policy component logging retry dw1.x

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -25,7 +25,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 65.1.0
+  version: 66.0.0-k8s-ops-logging-retry-dw-upgrade-rc3
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -25,7 +25,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 66.0.0-k8s-ops-logging-retry-dw-upgrade-rc5
+  version: 66.0.0-k8s-ops-logging-retry-dw-upgrade-rc6
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -25,7 +25,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 66.0.0-k8s-ops-logging-retry-dw-upgrade-rc3
+  version: 66.0.0-k8s-ops-logging-retry-dw-upgrade-rc5
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -25,7 +25,7 @@ services:
 - name: api-policy-component-sidekick@.service
   count: 2
 - name: api-policy-component@.service
-  version: 66.0.0-k8s-ops-logging-retry-dw-upgrade-rc6
+  version: 66.0.0
   count: 2
   sequentialDeployment: true
 - name: binary-ingester-sidekick@.service


### PR DESCRIPTION
- Reduce logging and ensure transaction_id is logged for every request
- Upgrade to Dropwizard 1.x
- Remove ResilientClient, so this service no longer performs retries