### PR TITLE
Added promotional variant fields

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -287,7 +287,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: 1.6.0
+  version: 1.7.0-k8s-rj-promotional-variants-rc1
   count: 2
   sequentialDeployment: true
 - name: methode-article-mapper-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -287,7 +287,7 @@ services:
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2
 - name: methode-article-internal-components-mapper@.service
-  version: 1.7.0-k8s-rj-promotional-variants-rc1
+  version: 1.7.0
   count: 2
   sequentialDeployment: true
 - name: methode-article-mapper-sidekick@.service


### PR DESCRIPTION
MAICM PR: https://github.com/Financial-Times/methode-article-internal-components-mapper/pull/27

Added 2 new fields to /internalcontent (internalcomponents collection):
- promotionalTitleVariant in alternativeTitles
- promotionalStandfirstVariant in alternativeStandfirsts

These fields are used for A/B testing.