### PR TITLE
FastFT articles are now syndicatable by default

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -507,7 +507,7 @@ services:
 - name: wordpress-article-mapper-sidekick@.service
   count: 2
 - name: wordpress-article-mapper@.service
-  version: 1.2.0-rj-fastft-syndicatable-rc3
+  version: 1.2.0
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -507,7 +507,7 @@ services:
 - name: wordpress-article-mapper-sidekick@.service
   count: 2
 - name: wordpress-article-mapper@.service
-  version: 1.2.0-rj-fastft-syndicatable-rc2
+  version: 1.2.0-rj-fastft-syndicatable-rc3
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -507,7 +507,7 @@ services:
 - name: wordpress-article-mapper-sidekick@.service
   count: 2
 - name: wordpress-article-mapper@.service
-  version: 1.1.2
+  version: 1.2.0-rj-fastft-syndicatable-rc1
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -507,7 +507,7 @@ services:
 - name: wordpress-article-mapper-sidekick@.service
   count: 2
 - name: wordpress-article-mapper@.service
-  version: 1.2.0-rj-fastft-syndicatable-rc1
+  version: 1.2.0-rj-fastft-syndicatable-rc2
   count: 2
 - name: wordpress-image-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
- wordpress-article-mapper: https://github.com/Financial-Times/wordpress-article-mapper/pull/22