### PR TITLE
Ingester env vars cleanup

### DIFF
--- a/complementarycontent-ingester@.service
+++ b/complementarycontent-ingester@.service
@@ -30,7 +30,6 @@ ExecStart=/bin/sh -c '\
   export WR_HC_TECH_SUMMARY="Tests that the build-info endpoint for the Document Store returns a 200 response"; \
   export JAVA_OPTS="-Xms256m -Xmx256m -XX:+UseG1GC -server"; \
   export PANIC_GUIDE_URL="https://dewey.ft.com/complementarycontent-ingester.html"; \
-  export COMPLEMENTARY_CONTENT_WRITER_PATH="${UPP_GATEWAY_PATH:-}/complementarycontent/{uuid}"; \
   /usr/bin/docker run --rm --name %p-%i_$(uuidgen) -p 8080 -p 8081 \
       --env "JAVA_OPTS=$JAVA_OPTS" \
       --env "APP_PORT=$APP_PORT" --env "ADMIN_PORT=$ADMIN_PORT" \
@@ -42,7 +41,7 @@ ExecStart=/bin/sh -c '\
       --env "MESSAGE_FORWARDING_ENABLED=true" --env "FORWARD_TO_TOPIC_NAME=PostPublicationEvents" \
       --env "KAFKA_PROXY_URL=%H:8080" \
       --env "PANIC_GUIDE_URL=$PANIC_GUIDE_URL"  \
-      --env "COMPLEMENTARY_CONTENT_WRITER_PATH=$COMPLEMENTARY_CONTENT_WRITER_PATH" \
+      --env "COMPLEMENTARY_CONTENT_WRITER_PATH=/complementarycontent/{uuid}" \
       nexus.in.ft.com:5000/coco/ingester:$DOCKER_APP_VERSION'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'

--- a/services.yaml
+++ b/services.yaml
@@ -31,7 +31,7 @@ services:
 - name: binary-ingester-sidekick@.service
   count: 2
 - name: binary-ingester@.service
-  version: 1.77.0
+  version: 1.77.1-k8s-cleanup-rc1
   count: 2
 - name: binary-writer-sidekick@.service
   count: 2
@@ -76,7 +76,7 @@ services:
 - name: complementarycontent-ingester-sidekick@.service
   count: 2
 - name: complementarycontent-ingester@.service
-  version: 1.77.0
+  version: 1.77.1-k8s-cleanup-rc1
   count: 2
 - name: concept-exporter-sidekick@.service
   count: 1
@@ -124,7 +124,7 @@ services:
 - name: content-collection-ingester-neo4j-sidekick@.service
   count: 2
 - name: content-collection-ingester-neo4j@.service
-  version: 1.77.0
+  version: 1.77.1-k8s-cleanup-rc1
   count: 2
 - name: content-collection-rw-neo4j-sidekick@.service
   count: 2
@@ -144,12 +144,12 @@ services:
 - name: content-ingester-neo4j-sidekick@.service
   count: 2
 - name: content-ingester-neo4j@.service
-  version: 1.77.0
+  version: 1.77.1-k8s-cleanup-rc1
   count: 2
 - name: content-ingester-sidekick@.service
   count: 2
 - name: content-ingester@.service
-  version: 1.77.0
+  version: 1.77.1-k8s-cleanup-rc1
   count: 2
 - name: content-preview-sidekick@.service
   count: 2
@@ -260,7 +260,7 @@ services:
 - name: list-notifications-ingester-sidekick@.service
   count: 2
 - name: list-notifications-ingester@.service
-  version: 1.77.0
+  version: 1.77.1-k8s-cleanup-rc1
   count: 2
 - name: list-notifications-push-sidekick@.service
   count: 2
@@ -362,7 +362,7 @@ services:
 - name: notifications-ingester-sidekick@.service
   count: 2
 - name: notifications-ingester@.service
-  version: 1.77.0
+  version: 1.77.1-k8s-cleanup-rc1
   count: 2
 - name: notifications-push-sidekick@.service
   count: 2
@@ -453,7 +453,7 @@ services:
 - name: rec-reads-content-ingester-sidekick@.service
   count: 1
 - name: rec-reads-content-ingester@.service
-  version: 1.77.0
+  version: 1.77.1-k8s-cleanup-rc1
   count: 1
 - name: relations-api-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -31,7 +31,7 @@ services:
 - name: binary-ingester-sidekick@.service
   count: 2
 - name: binary-ingester@.service
-  version: 1.77.1-k8s-cleanup-rc1
+  version: 1.77.1
   count: 2
 - name: binary-writer-sidekick@.service
   count: 2
@@ -76,7 +76,7 @@ services:
 - name: complementarycontent-ingester-sidekick@.service
   count: 2
 - name: complementarycontent-ingester@.service
-  version: 1.77.1-k8s-cleanup-rc1
+  version: 1.77.1
   count: 2
 - name: concept-exporter-sidekick@.service
   count: 1
@@ -124,7 +124,7 @@ services:
 - name: content-collection-ingester-neo4j-sidekick@.service
   count: 2
 - name: content-collection-ingester-neo4j@.service
-  version: 1.77.1-k8s-cleanup-rc1
+  version: 1.77.1
   count: 2
 - name: content-collection-rw-neo4j-sidekick@.service
   count: 2
@@ -144,12 +144,12 @@ services:
 - name: content-ingester-neo4j-sidekick@.service
   count: 2
 - name: content-ingester-neo4j@.service
-  version: 1.77.1-k8s-cleanup-rc1
+  version: 1.77.1
   count: 2
 - name: content-ingester-sidekick@.service
   count: 2
 - name: content-ingester@.service
-  version: 1.77.1-k8s-cleanup-rc1
+  version: 1.77.1
   count: 2
 - name: content-preview-sidekick@.service
   count: 2
@@ -260,7 +260,7 @@ services:
 - name: list-notifications-ingester-sidekick@.service
   count: 2
 - name: list-notifications-ingester@.service
-  version: 1.77.1-k8s-cleanup-rc1
+  version: 1.77.1
   count: 2
 - name: list-notifications-push-sidekick@.service
   count: 2
@@ -362,7 +362,7 @@ services:
 - name: notifications-ingester-sidekick@.service
   count: 2
 - name: notifications-ingester@.service
-  version: 1.77.1-k8s-cleanup-rc1
+  version: 1.77.1
   count: 2
 - name: notifications-push-sidekick@.service
   count: 2
@@ -453,7 +453,7 @@ services:
 - name: rec-reads-content-ingester-sidekick@.service
   count: 1
 - name: rec-reads-content-ingester@.service
-  version: 1.77.1-k8s-cleanup-rc1
+  version: 1.77.1
   count: 1
 - name: relations-api-sidekick@.service
   count: 2


### PR DESCRIPTION
fixed complementarycontent-ingester's env vars and all ingesters to version 1.77.1-k8s-cleanup-rc1

https://trello.com/c/1MmRqXM0/131-image-resolver-to-handle-empty-lead-images-correctly-and-content-public-read-to-handle-empty-requests-gracefully

https://github.com/Financial-Times/ingester/pull/6