### PR TITLE
image-resolver simplification

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -220,7 +220,7 @@ services:
 - name: image-resolver-sidekick@.service
   count: 2
 - name: image-resolver@.service
-  version: 2.1.1-k8s-simplification-rc3
+  version: 2.1.1
   count: 2
   sequentialDeployment: true
 - name: industry-classifications-rw-neo4j-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -220,7 +220,7 @@ services:
 - name: image-resolver-sidekick@.service
   count: 2
 - name: image-resolver@.service
-  version: 2.1.0
+  version: 2.1.1-k8s-simplification-rc1
   count: 2
   sequentialDeployment: true
 - name: industry-classifications-rw-neo4j-sidekick@.service

--- a/services.yaml
+++ b/services.yaml
@@ -220,7 +220,7 @@ services:
 - name: image-resolver-sidekick@.service
   count: 2
 - name: image-resolver@.service
-  version: 2.1.1-k8s-simplification-rc1
+  version: 2.1.1-k8s-simplification-rc3
   count: 2
   sequentialDeployment: true
 - name: industry-classifications-rw-neo4j-sidekick@.service


### PR DESCRIPTION
image-resolver:2.1.1-k8s-simplification-rc1 - no http call if no images to resolve + tid propagated

https://trello.com/c/1MmRqXM0/131-image-resolver-to-handle-empty-lead-images-correctly-and-content-public-read-to-handle-empty-requests-gracefully

https://github.com/Financial-Times/image-resolver/pull/8
