### PR TITLE
Fix complementarycontent brands

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -304,7 +304,7 @@ services:
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2
 - name: methode-content-placeholder-mapper@.service
-  version: 1.0.3
+  version: 1.0.4-k8s-fix-complementarycontent-brands-rc1
   count: 2
 - name: methode-image-binary-mapper-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -304,7 +304,7 @@ services:
 - name: methode-content-placeholder-mapper-sidekick@.service
   count: 2
 - name: methode-content-placeholder-mapper@.service
-  version: 1.0.4-k8s-fix-complementarycontent-brands-rc1
+  version: 1.0.4
   count: 2
 - name: methode-image-binary-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
Internal content placeholder complementarycontent has its brands set from the db content.
https://github.com/Financial-Times/methode-content-placeholder-mapper/pull/21