### PR TITLE
Helm config only: Added bucket region value for the S3 bucket

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -213,7 +213,7 @@ services:
 - name: generic-rw-s3-sidekick@.service
   count: 1
 - name: generic-rw-s3@.service
-  version: 1.4.0
+  version: 1.4.1
   count: 1
 - name: image-cleaner.service
   version: 1.0.0


### PR DESCRIPTION
Release https://github.com/Financial-Times/generic-rw-s3/releases/tag/1.4.1
PR: https://github.com/Financial-Times/generic-rw-s3/pull/18