### PR TITLE
k8s fix: Make kafka group name unique

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -367,7 +367,7 @@ services:
 - name: notifications-push-sidekick@.service
   count: 2
 - name: notifications-push@.service
-  version: 3.5.2
+  version: 3.5.3
   count: 2
   sequentialDeployment: true
 - name: notifications-rw-sidekick@.service


### PR DESCRIPTION
Using the pod name as the group name
PR: https://github.com/Financial-Times/notifications-push/pull/55