### PR TITLE
UPP exports - k8s run in parallel

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -494,7 +494,7 @@ services:
 - name: upp-exports-rw-s3-sidekick@.service
   count: 1
 - name: upp-exports-rw-s3@.service
-  version: 1.1.0
+  version: 1.2.0
   count: 1
 - name: v2-content-annotator-sidekick@.service
   count: 2


### PR DESCRIPTION
New version of `upp-exports`, containing helm changes (run k8s in parallel with CoCo)