### PR TITLE
Have unique tids for video metadata in all envs. 

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -71,7 +71,7 @@ services:
 - name: cms-notifier-sidekick@.service
   count: 1
 - name: cms-notifier@.service
-  version: 1.57.0-k8s-fd-unique-video-metadata-tid-rc1
+  version: 1.57.0
   count: 1
 - name: complementarycontent-ingester-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -71,7 +71,7 @@ services:
 - name: cms-notifier-sidekick@.service
   count: 1
 - name: cms-notifier@.service
-  version: 1.56.0
+  version: 1.57.0-k8s-fd-unique-video-metadata-tid-rc1
   count: 1
 - name: complementarycontent-ingester-sidekick@.service
   count: 2


### PR DESCRIPTION
Original [PR](https://github.com/Financial-Times/cms-notifier/pull/9)

⚠️ This version of the repo doesn't have the video splitting activated anyway, this release is only required to have the same version of the app deployed in all the envs.

The service version will be updated once the changes are ready to go to pre-prod.