### PR TITLE
Releasing concept-suggestion-api 1.47.1

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -108,7 +108,7 @@ services:
 - name: concept-suggestion-api-sidekick@.service
   count: 1
 - name: concept-suggestion-api@.service
-  version: 1.47.0
+  version: 1.47.1
   count: 1
 - name: concepts-kafka-bridge-pub-prod-sidekick@.service
   count: 1


### PR DESCRIPTION
Helm config only: moved ces host to global config 
https://github.com/Financial-Times/concept-suggestion-api/releases/tag/1.47.1 

PR https://github.com/Financial-Times/concept-suggestion-api/pull/4