### PR TITLE
Releasing bridges 15.0.3

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -47,25 +47,25 @@ services:
 - name: cms-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod-uk@.service
-  version: 15.0.2
+  version: 15.0.3
   count: 2
   sequentialDeployment: true
 - name: cms-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod-us@.service
-  version: 15.0.2
+  version: 15.0.3
   count: 2
   sequentialDeployment: true
 - name: cms-metadata-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-uk@.service
-  version: 15.0.2
+  version: 15.0.3
   count: 2
   sequentialDeployment: true
 - name: cms-metadata-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-us@.service
-  version: 15.0.2
+  version: 15.0.3
   count: 2
   sequentialDeployment: true
 - name: cms-notifier-sidekick@.service
@@ -113,7 +113,7 @@ services:
 - name: concepts-kafka-bridge-pub-prod-sidekick@.service
   count: 1
 - name: concepts-kafka-bridge-pub-prod@.service
-  version: 15.0.2
+  version: 15.0.3
   count: 1
 - name: concepts-rw-neo4j-sidekick@.service
   count: 2


### PR DESCRIPTION
Added bridges from prod k8s to prod coco
Adjusted the default bridges from team clusters to go to prod k8s.
Fixes:
Bridging the the CMS pre native topics from publishing
Pointed CMS bridges to CMS notifier
Release link: https://github.com/Financial-Times/coco-kafka-bridge/releases/tag/15.0.3
PR: https://github.com/Financial-Times/coco-kafka-bridge/pull/47