### PR TITLE
Concept exporter: updates for k8s

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -81,7 +81,7 @@ services:
 - name: concept-exporter-sidekick@.service
   count: 1
 - name: concept-exporter@.service
-  version: 1.0.0
+  version: 1.0.1-k8s-hc-rc11
   count: 1
 - name: concept-ingester-sidekick@.service
   count: 2

--- a/services.yaml
+++ b/services.yaml
@@ -81,7 +81,7 @@ services:
 - name: concept-exporter-sidekick@.service
   count: 1
 - name: concept-exporter@.service
-  version: 1.0.1-k8s-hc-rc11
+  version: 1.1.0
   count: 1
 - name: concept-ingester-sidekick@.service
   count: 2

--- a/upp-exports-rw-s3@.service
+++ b/upp-exports-rw-s3@.service
@@ -16,7 +16,7 @@ ExecStartPre=/bin/bash -c 'docker history coco/upp-exports-rw-s3:$DOCKER_APP_VER
 
 ExecStart=/bin/sh -c '\
     export ENV=$(/usr/bin/etcdctl get /ft/config/environment_tag); \
-    export AWS_REGION=$(/usr/bin/etcdctl get /ft/config/upp-exports-rw-s3/aws_region); \
+    export AWS_REGION=$(/usr/bin/etcdctl get /ft/config/bucket_region); \
     export AWS_ACCESS_KEY_ID=$(/usr/bin/etcdctl get /ft/_credentials/aws/aws_access_key_id); \
     export AWS_SECRET_ACCESS_KEY=$(/usr/bin/etcdctl get /ft/_credentials/aws/aws_secret_access_key); \
     export BUCKET_NAME=$(/usr/bin/etcdctl get /ft/config/upp-exports-rw-s3/bucket); \


### PR DESCRIPTION
Tag: https://github.com/Financial-Times/concept-exporter/releases/tag/1.1.0
Needed for K8s work:

* healthcheck (max 10s)
* gtg check (max 3s)
* pod affinity
* memory limit and request

Also fixed healthcheck issues when exporting organisations and including https://github.com/Financial-Times/up-service-files/pull/1470