### PR TITLE
Releasing methode article mapper 1.6.3

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -293,7 +293,7 @@ services:
 - name: methode-article-mapper-sidekick@.service
   count: 2
 - name: methode-article-mapper@.service
-  version: 1.6.2
+  version: 1.6.3
   count: 2
   sequentialDeployment: true
 - name: methode-content-collection-mapper-sidekick@.service


### PR DESCRIPTION
K8s: Increase memory limit to 1Gi for K8s
PR: https://github.com/Financial-Times/methode-article-mapper/pull/41
Release: https://github.com/Financial-Times/methode-article-mapper/releases/tag/1.6.3