### PR TITLE
Releasing methode list mapper 1.2.1

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -324,7 +324,7 @@ services:
 - name: methode-list-mapper-sidekick@.service
   count: 2
 - name: methode-list-mapper@.service
-  version: 1.2.0
+  version: 1.2.1
   count: 2
 - name: mongo-backup@.service
   version: v20.0.1


### PR DESCRIPTION
k8s: Increase memory limit to 1Gi for K8S
PR: https://github.com/Financial-Times/methode-list-mapper/pull/7
Release: https://github.com/Financial-Times/methode-list-mapper/releases/tag/1.2.1