### PR TITLE
Releasing methode article image set mapper 1.4.1

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -282,7 +282,7 @@ services:
 - name: methode-article-image-set-mapper-sidekick@.service
   count: 2
 - name: methode-article-image-set-mapper@.service
-  version: 1.4.0
+  version: 1.4.1
   count: 2
 - name: methode-article-internal-components-mapper-sidekick@.service
   count: 2


### PR DESCRIPTION
k8s: k8s: Increase memory limit to 256Mi for K8S
PR: https://github.com/Financial-Times/methode-article-image-set-mapper/pull/7
Release: https://github.com/Financial-Times/methode-article-image-set-mapper/releases/tag/1.4.1