### PR TITLE
coreos-version-checker-upgrade

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -176,7 +176,7 @@ services:
   count: 2
 - name: coreos-version-checker-sidekick.service
 - name: coreos-version-checker.service
-  version: 1.1.2
+  version: 1.1.3
 - name: diamond.service
   version: v1.1.0
 - name: document-store-api-sidekick@.service


### PR DESCRIPTION
https://github.com/Financial-Times/coreos-version-checker/pull/8
- gtg endpoint
- gtg/health timeouts
- resource limits
- non-standard channel handling for K8S