### PR TITLE
Load replicator changes

### DIFF
--- a/load-replicator@.service
+++ b/load-replicator@.service
@@ -28,8 +28,8 @@ ExecStart=/bin/sh -c '\
   coco/load-replicator:$DOCKER_APP_VERSION'
 
 ExecStop=-/bin/bash -c 'docker stop -t 3 "$(docker ps -q --filter=name=^/%p-%i_)"'
-Restart=no
-RuntimeMaxSec=32400
+Restart=on-failure
+RestartSec=60
 
 [X-Fleet]
 Conflicts=%p@*.service

--- a/load-replicator@.timer
+++ b/load-replicator@.timer
@@ -2,7 +2,7 @@
 Description=Runs the Load Replicator
 
 [Timer]
-OnCalendar=Mon,Tue,Wed,Thu,Fri *-*-* 09:00:00
+OnCalendar=Mon,Tue,Wed,Thu,Fri *-*-* 07:00:00
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Start the service at 7AM on weekdays and does not run on weekends.
The service will be run for a certain duration (11 hours) to cover romanian and UK work timings.
Duration will be set as an etcd key

Tested the changes in the dynpub cluster. The service goes into a `inactive` state after the duration specified. So added restart `on-failure`.