### PR TITLE
system-healthcheck improvements

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -488,7 +488,7 @@ services:
   count: 1
 - name: system-healthcheck-sidekick.service
 - name: system-healthcheck.service
-  version: 1.0.10
+  version: 1.0.11
 - name: tunnel-registrator.service
   version: v1.0.3
 - name: up-queue-sender-v1-metadata-sidekick@.service


### PR DESCRIPTION
- added memory request, lowered limit based on docker stats
- cleaned up helm config files
- switched to circleCI 2
- vendored dependencies
- updated hc library
- deleted unused checks
- removed check for port 8080, which is only needed for vulcan

https://github.com/Financial-Times/coco-system-healthcheck/pull/47