### PR TITLE
kafka-lagcheck affinity

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -254,7 +254,7 @@ services:
 - name: kafka-lagcheck-sidekick@.service
   count: 1
 - name: kafka-lagcheck@.service
-  version: 2.0.4
+  version: 2.0.5
   count: 1
 - name: kafka-rest-proxy-sidekick@.service
   count: 1


### PR DESCRIPTION
https://github.com/Financial-Times/kafka-lagcheck/pull/8

tested in: xp, pre-prod, k8s del and pub clusters