### PR TITLE
Releasing bridges 15.1.1 to pre-prod

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -52,49 +52,49 @@ services:
 - name: cms-kafka-bridge-pub-pre-prod-uk-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-pre-prod-uk@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 2
   sequentialDeployment: true
 - name: cms-kafka-bridge-pub-pre-prod-us-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-pre-prod-us@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 2
   sequentialDeployment: true
 - name: cms-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod-uk@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 2
   sequentialDeployment: true
 - name: cms-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-kafka-bridge-pub-prod-us@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 2
   sequentialDeployment: true
 - name: cms-metadata-kafka-bridge-pub-pre-prod-uk-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-pre-prod-uk@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 2
   sequentialDeployment: true
 - name: cms-metadata-kafka-bridge-pub-pre-prod-us-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-pre-prod-us@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 2
   sequentialDeployment: true
 - name: cms-metadata-kafka-bridge-pub-prod-uk-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-uk@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 2
   sequentialDeployment: true
 - name: cms-metadata-kafka-bridge-pub-prod-us-sidekick@.service
   count: 2
 - name: cms-metadata-kafka-bridge-pub-prod-us@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 2
   sequentialDeployment: true
 - name: cms-notifier-sidekick@.service
@@ -142,12 +142,12 @@ services:
 - name: concepts-kafka-bridge-pub-pre-prod-uk-sidekick@.service
   count: 1
 - name: concepts-kafka-bridge-pub-pre-prod-uk@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 1
 - name: concepts-kafka-bridge-pub-pre-prod-us-sidekick@.service
   count: 1
 - name: concepts-kafka-bridge-pub-pre-prod-us@.service
-  version: 15.1.0
+  version: 15.1.1
   count: 1
 - name: concepts-rw-neo4j-sidekick@.service
   count: 2


### PR DESCRIPTION
Adjusted bridges for k8s staging env.

Release link: https://github.com/Financial-Times/coco-kafka-bridge/releases/tag/15.1.1
PR: https://github.com/Financial-Times/coco-kafka-bridge/pull/49